### PR TITLE
Improve error management

### DIFF
--- a/.github/workflows/check_conda_recipe.yml
+++ b/.github/workflows/check_conda_recipe.yml
@@ -5,10 +5,9 @@ on:
   # Triggers the workflow on schedule but only for the default branch (which is master)
   schedule:
    - cron: '0 7 5,20 * *'
-# on: [push] #to any branch
 
   # Allows you to run this workflow manually from the Actions tab
-  # workflow_dispatch:
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -18,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest','macos-latest']
+        os: ['ubuntu-latest','macos-13']
         python-version: ['3.8']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/binette/main.py
+++ b/binette/main.py
@@ -151,6 +151,13 @@ def parse_input_files(bin_dirs: List[str], contig2bin_tables: List[str], contigs
 
     logging.info(f"Parsing contig fasta file: {contigs_fasta}")
     contigs_object = contig_manager.parse_fasta_file(contigs_fasta)
+
+    unexpected_contigs = {contig for contig in contigs_in_bins if contig not in contigs_object}
+
+    if len(unexpected_contigs):
+        raise ValueError(f"{len(unexpected_contigs)} contigs from the input bins were not found in the contigs file '{contigs_fasta}'. "
+                        f"The missing contigs are: {', '.join(unexpected_contigs)}. Please ensure all contigs from input bins are present in contig file.")
+
     contig_to_length = {seq.name: len(seq) for seq in contigs_object if seq.name in contigs_in_bins}
 
     return bin_set_name_to_bins, original_bins, contigs_in_bins, contig_to_length


### PR DESCRIPTION
This small PR improves error management by ensuring that all contigs from bins are found in the input contig file. Previously, missing contigs would cause Binette to fail with an obscure error message (see issue #11).

Additionally, this PR addresses the macOS GitHub runner crash in the GitHub Actions. The crash was due to "macos-latest" transitioning to macOS 14 with runners using the OSX-arm64 architecture, which is currently unsupported in Bioconda.