### PR TITLE
Provide Precomputed Protein Sequences  

### DIFF
--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -96,3 +96,16 @@ jobs:
         python scripts/compare_results.py expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
 
 
+    - name: Run simple test case from bin dirs and with proteins input
+      run: |
+        cd test_data
+        binette -d binning_results/A/ binning_results/B/ binning_results/C/ \
+                --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs_and_prot_input --proteins proteins.faa
+
+    - name: Compare results from bin dirs with expectation
+      run: |
+        cd test_data
+        head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
+        python scripts/compare_results.py expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
+
+

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Compare results from bin dirs with expectation
       run: |
         cd test_data
-        head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
+        head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
         python scripts/compare_results.py expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
 
 

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -167,8 +167,8 @@ def check_contig_consistency(contigs_from_assembly: Iterable[str],
 
     issue_countigs = len(set(contigs_from_elsewhere) - set(contigs_from_assembly))
     
-    message = f"{issue_countigs} contigs found in file {elsewhere_file} \
-                were not found in assembly_file ({assembly_file})."
+    message = (f"{issue_countigs} contigs found in file '{elsewhere_file}' "
+    f"were not found in assembly_file '{assembly_file}'")
     assert are_contigs_consistent, message
 
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -389,10 +389,12 @@ def main():
     use_existing_protein_file = False
 
     if args.proteins:
-        faa_file = args.protein
+        logging.info(f"Using the provided protein sequences file: {args.proteins}")
+        faa_file = args.proteins
         use_existing_protein_file = True
     else:
         faa_file = out_tmp_dir / "assembly_proteins.faa"
+
 
     diamond_result_file = out_tmp_dir / "diamond_result.tsv"
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -10,7 +10,6 @@ Portability : POSIX
 
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Action, Namespace
 
-from email.parser import Parser
 import sys
 import logging
 import os

--- a/binette/main.py
+++ b/binette/main.py
@@ -236,7 +236,9 @@ def parse_input_files(bin_dirs: List[Path],
 
 def manage_protein_alignement(faa_file: Path, contigs_fasta: Path, contig_to_length: Dict[str, int],
                                 contigs_in_bins: Set[str], diamond_result_file: Path,
-                                checkm2_db: Optional[Path], threads: int, use_existing_protein_file: bool, low_mem: bool) -> Tuple[Dict[str, int], Dict[str, List[str]]]:
+                                checkm2_db: Optional[Path], threads: int, use_existing_protein_file: bool, 
+                                resume_diamond:bool,
+                                low_mem: bool) -> Tuple[Dict[str, int], Dict[str, List[str]]]:
     """
     Predicts or reuses proteins prediction and runs diamond on them.
     
@@ -248,6 +250,7 @@ def manage_protein_alignement(faa_file: Path, contigs_fasta: Path, contig_to_len
     :param checkm2_db: The path to the CheckM2 database.
     :param threads: Number of threads for parallel processing.
     :param use_existing_protein_file: Boolean indicating whether to use an existing protein file.
+    :param resume_diamond: Boolean indicating whether to resume diamond alignement.
     :param low_mem: Boolean indicating whether to use low memory mode.
 
     :return: A tuple containing dictionaries - contig_to_kegg_counter and contig_to_genes.
@@ -263,6 +266,7 @@ def manage_protein_alignement(faa_file: Path, contigs_fasta: Path, contig_to_len
         contigs_iterator = (s for s in contig_manager.parse_fasta_file(contigs_fasta.as_posix()) if s.name in contigs_in_bins)
         contig_to_genes = cds.predict(contigs_iterator, faa_file.as_posix(), threads)
 
+    if not resume_diamond:
         if checkm2_db is None:
             # get checkm2 db stored in checkm2 install
             diamond_db_path = diamond.get_checkm2_db()
@@ -411,7 +415,8 @@ def main():
     contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(faa_file=faa_file, contigs_fasta=args.contigs, contig_to_length=contig_to_length,
                                                                         contigs_in_bins=contigs_in_bins,
                                                                         diamond_result_file=diamond_result_file, checkm2_db=args.checkm2_db,
-                                                                        threads=args.threads, use_existing_protein_file=use_existing_protein_file, low_mem=args.low_mem)
+                                                                        threads=args.threads, use_existing_protein_file=use_existing_protein_file, 
+                                                                        resume_diamond=args.resume, low_mem=args.low_mem)
     
     # Use contig index instead of contig name to save memory
     contig_to_index, index_to_contig = contig_manager.make_contig_index(contigs_in_bins)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,6 +58,20 @@ For example, consider the following two `contig2bin_tables`:
 
 In both formats, the `--contigs` argument should specify a FASTA file containing all the contigs found in the bins. Typically, this file would be the assembly FASTA file used to generate the bins. In these exemple the `assembly.fasta` file should contain at least the five contigs mentioned in the `contig2bin_tables` files or in the bin fasta files: `contig_1`, `contig_8`, `contig_15`, `contig_9`, and `contig_10`.
 
+
+## Providing Protein Sequences
+
+You can provide protein sequences in FASTA format to Binette using the `--proteins` argument. The sequence identifiers must follow the Prodigal convention: `<contigID>_<GeneID>`. This naming format ensures proper mapping of each gene to its corresponding contig.  
+
+By using this option, the gene prediction step is skipped.  
+
+### Example  
+If your contig is named `contig_A`, the gene identifiers should follow this pattern:  
+- `contig_A_1`  
+- `contig_A_2`  
+- `contig_A_3`  
+
+
 ## Outputs
 
 Binette results are stored in the `results` directory. You can specify a different directory using the `--outdir` option.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,9 +59,9 @@ For example, consider the following two `contig2bin_tables`:
 In both formats, the `--contigs` argument should specify a FASTA file containing all the contigs found in the bins. Typically, this file would be the assembly FASTA file used to generate the bins. In these exemple the `assembly.fasta` file should contain at least the five contigs mentioned in the `contig2bin_tables` files or in the bin fasta files: `contig_1`, `contig_8`, `contig_15`, `contig_9`, and `contig_10`.
 
 
-## Providing Protein Sequences
+## Providing Precomputed Protein Sequences
 
-You can provide protein sequences in FASTA format to Binette using the `--proteins` argument. The sequence identifiers must follow the Prodigal convention: `<contigID>_<GeneID>`. This naming format ensures proper mapping of each gene to its corresponding contig.  
+You can provide protein sequences in FASTA format to Binette using the `--proteins` argument. The sequence identifiers must follow the Prodigal convention: `<contigID>_<GeneID>`. This naming format ensures proper mapping of each gene to its contig.  
 
 By using this option, the gene prediction step is skipped.  
 

--- a/tests/main_binette_test.py
+++ b/tests/main_binette_test.py
@@ -100,7 +100,7 @@ def test_manage_protein_alignement_resume(tmp_path):
 
     faa_file = tmp_path / "proteins.faa"
     faa_file_content = (
-    ">contig1_1\nACGT\n>contig2_1\nTGCA\n>contig2_2\nAAAA\n>contig3_1\nCCCC\n"
+    ">contig1_1\nMCGT\n>contig2_1\nTGCA\n>contig2_2\nAAAA\n>contig3_1\nCCCC\n"
     )
 
     contig_to_length={"contig1":40, "contig2":80, "contig3":20}
@@ -127,6 +127,7 @@ def test_manage_protein_alignement_resume(tmp_path):
             checkm2_db=None,
             threads=1,
             use_existing_protein_file=True,
+            resume_diamond=True,
             low_mem=False
         )
 
@@ -141,7 +142,7 @@ def test_manage_protein_alignement_not_resume(tmpdir, tmp_path):
 
     faa_file = tmp_path / "proteins.faa"
     faa_file_content = (
-    ">contig1_1\nACGT\n>contig2_1\nTGCA\n>contig2_2\nAAAA\n>contig3_1\nCCCC\n"
+    ">contig1_1\nMLKPACGT\n>contig2_1\nMMMKPTGCA\n>contig2_2\nMMMAAAA\n>contig3_1\nMLPALP\n"
     )
 
     contig_to_length={"contig1":40, "contig2":80, "contig3":20}
@@ -172,6 +173,7 @@ def test_manage_protein_alignement_not_resume(tmpdir, tmp_path):
             checkm2_db=None,
             threads=1,
             use_existing_protein_file=True,
+            resume_diamond=True,
             low_mem=False
         )
 
@@ -352,7 +354,7 @@ def test_manage_protein_alignment_no_resume(tmp_path):
         # Call the function
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file, contigs_fasta, contig_to_length, contigs_in_bins,
-            diamond_result_file, checkm2_db, threads, resume, low_mem
+            diamond_result_file, checkm2_db, threads, resume, resume, low_mem
         )
         
         # Assertions to check if functions were called


### PR DESCRIPTION
This PR adds the ability to provide precomputed protein sequences as input, eliminating the need for Binette to perform gene prediction. This feature addresses the request in issue #30.  

### Usage  
A new argument, `--proteins`, has been introduced. This should point to a FASTA file containing all predicted proteins for the assembly.  

### Requirements  
The provided protein sequences must follow Pyrodigal’s naming convention: `<contigID>_<GeneID>`.  
- `<contigID>`: The name of the contig.
- `<GeneID>`: An integer identifying the gene.  

If a contig extracted from the protein file is not present in the provided contig file, the program will raise an error to ensure consistency between inputs.  
