### PR TITLE
Fix wrong input proteins management

### DIFF
--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -385,21 +385,9 @@ def get_intersection_bins(G: nx.Graph) -> Set[Bin]:
         bins_combinations = get_all_possible_combinations(clique)
         for bins in bins_combinations:
             if max((b.completeness for b in bins)) < 40:
-                # logging.debug(
-                #     "completeness is not good enough to create a new bin on intersection"
-                # )
-                # logging.debug(
-                #     f"{[(str(b), b.completeness, b.contamination)  for b in bins]}"
-                # )
                 continue
 
             intersec_bin = bins[0].intersection(*bins[1:])
-
-            # if intersec_bin in clique:
-            #     print("=" * 10, "****intersec_bin in clique", intersec_bin)
-
-            # if intersec_bin in G:
-            #     print("=" * 10, "****intersec_bin in clique", intersec_bin)
 
             if intersec_bin.contigs:  # and intersec_bin not in clique:
 
@@ -425,19 +413,8 @@ def get_difference_bins(G: nx.Graph) -> Set[Bin]:
 
             for bin_a in bins:
                 if bin_a.completeness < 40:
-                    # logging.debug(
-                    #     f"completeness of {bin_a} is not good enough to do difference... "
-                    # )
-                    # logging.debug(
-                    #     f"{[(str(b), b.completeness, b.contamination)  for b in bins]}"
-                    # )
                     continue
                 bin_diff = bin_a.difference(*(b for b in bins if b != bin_a))
-                # if bin_diff in clique:
-                #     print("=" * 10, "****bin_diff in clique", bin_diff)
-
-                # if bin_diff in G:
-                #     print("=" * 10, "****bin_diff in clique", bin_diff)
 
                 if bin_diff.contigs:  # and bin_diff not in clique:
                     difference_bins.add(bin_diff)
@@ -459,23 +436,11 @@ def get_union_bins(G: nx.Graph, max_conta: int = 50) -> Set[Bin]:
         bins_combinations = get_all_possible_combinations(clique)
         for bins in bins_combinations:
             if max((b.contamination for b in bins)) > 20:
-                # logging.debug(
-                #     "Some bin are too contaminated to make a useful union bin"
-                # )
-                # logging.debug(
-                #     f"{[(str(b), b.completeness, b.contamination)  for b in bins]}"
-                # )
                 continue
 
             bins = set(bins)
             bin_a = bins.pop()
             bin_union = bin_a.union(*bins)
-            # if bin_union in clique:
-            #     print("=" * 10, "****bin_union in clique", bin_union)
-
-            # if bin_union in G:
-            #     print("=" * 10, "****bin_union in clique", bin_union)
-
             if bin_union.contigs:  # and bin_union not in clique:
                 union_bins.add(bin_union)
 
@@ -636,34 +601,22 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
     :return: A set of intermediate bins created from intersections, differences, and unions.
     """
 
-    # original_bin_hashes = [b.hash for b in original_bins]
-
     logging.info("Making bin graph...")
     connected_bins_graph = from_bins_to_bin_graph(original_bins)
 
     logging.info("Creating intersection bins...")
     intersection_bins = get_intersection_bins(connected_bins_graph)
-    # intersection_bins = {
-    #     bin_obj
-    #     for bin_obj in intersection_bins
-    #     if bin_obj.hash not in original_bin_hashes
-    # }
+
     logging.info(f"{len(intersection_bins)} bins created on intersections.")
 
     logging.info("Creating difference bins...")
     difference_bins = get_difference_bins(connected_bins_graph)
-    # difference_bins = {
-    #     bin_obj
-    #     for bin_obj in difference_bins
-    #     if bin_obj.hash not in original_bin_hashes
-    # }
+
     logging.info(f"{len(difference_bins)} bins created based on symmetric difference.")
 
     logging.info("Creating union bins...")
     union_bins = get_union_bins(connected_bins_graph)
-    # union_bins = {
-    #     bin_obj for bin_obj in union_bins if bin_obj.hash not in original_bin_hashes
-    # }
+
     logging.info(f"{len(union_bins)} bins created on unions.")
 
     new_bins = difference_bins | intersection_bins | union_bins

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -72,7 +72,7 @@ def write_faa(outfaa: str, contig_to_genes: List[Tuple[str, pyrodigal.Genes]]) -
 
     """
     logging.info("Writing predicted protein sequences.")
-    with open(outfaa, "w") as fl:
+    with gzip.open(outfaa, "wt") as fl:
         for contig_id, genes in contig_to_genes:
             genes.write_translations(fl, contig_id)
 
@@ -236,12 +236,6 @@ def filter_faa_file(
     This function processes the input FASTA file, identifies protein sequences
     originating from contigs listed in `contigs_to_keep`, and writes the filtered
     sequences to a new FASTA file. The output file supports optional `.gz` compression.
-
-    Metrics computed and logged:
-    - Total number of contigs in `contigs_to_keep`.
-    - Number and proportion of contigs with at least one protein-coding gene.
-    - Number and proportion of contigs without any protein-coding genes.
-    - Number of contigs from the input FASTA file that are not in `contigs_to_keep`.
 
     :param contigs_to_keep: A set of contig names to retain in the output FASTA file.
     :param input_faa_file: Path to the input FASTA file containing protein sequences.

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -266,10 +266,10 @@ def filter_faa_file(
     # Log the computed metrics
     logging.info(f"Processing protein sequences from '{input_faa_file}'.")
     logging.info(
-        f"Filtered {input_faa_file} to retain genes from {total_contigs} contigs that are included the input bins."
+        f"Filtered {input_faa_file} to retain genes from {total_contigs} contigs that are included in the input bins."
     )
-    logging.info(
-        f"Found {contigs_with_no_genes} contigs ({contigs_with_no_genes / total_contigs:.2%}) with no genes."
+    logging.debug(
+        f"Found {contigs_with_no_genes}/{total_contigs}  contigs ({contigs_with_no_genes / total_contigs:.2%}) with no genes."
     )
     logging.debug(
         f"{contigs_not_in_keep_list} contigs from the input FASTA file are not in the keep list."

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -211,19 +211,6 @@ def get_contig_cds_metadata(
     return contig_info
 
 
-from typing import Set
-from pathlib import Path
-import gzip
-import pyfastx
-import logging
-
-from typing import Set
-from pathlib import Path
-import gzip
-import pyfastx
-import logging
-
-
 def filter_faa_file(
     contigs_to_keep: Set[str],
     input_faa_file: Path,

--- a/binette/contig_manager.py
+++ b/binette/contig_manager.py
@@ -2,7 +2,7 @@ import pyfastx
 from typing import Dict, Iterable, Tuple, Set, Any, Union
 
 
-def parse_fasta_file(fasta_file: str) -> pyfastx.Fasta:
+def parse_fasta_file(fasta_file: str, index_file: str) -> pyfastx.Fasta:
     """
     Parse a FASTA file and return a pyfastx.Fasta object.
 
@@ -10,7 +10,7 @@ def parse_fasta_file(fasta_file: str) -> pyfastx.Fasta:
 
     :return: A pyfastx.Fasta object representing the parsed FASTA file.
     """
-    fa = pyfastx.Fasta(fasta_file, build_index=True)
+    fa = pyfastx.Fasta(fasta_file, build_index=True, index_file=index_file)
     return fa
 
 

--- a/binette/diamond.py
+++ b/binette/diamond.py
@@ -92,6 +92,7 @@ def run(
         f"-o {output} "
         f"--threads {threads} "
         f"--db {db} "
+        f"--compress 1 "
         f"--query-cover {query_cover} "
         f"--subject-cover {subject_cover} "
         f"--id {percent_id} "

--- a/binette/main.py
+++ b/binette/main.py
@@ -315,9 +315,9 @@ def manage_protein_alignement(
 
     else:
         contigs_iterator = (
-            s
-            for s in contig_manager.parse_fasta_file(contigs_fasta.as_posix())
-            if s.name in contigs_in_bins
+            seq
+            for seq in contig_manager.parse_fasta_file(contigs_fasta.as_posix())
+            if seq.name in contigs_in_bins
         )
         contig_to_genes = cds.predict(contigs_iterator, faa_file.as_posix(), threads)
 
@@ -330,7 +330,10 @@ def manage_protein_alignement(
         else:
             raise FileNotFoundError(checkm2_db)
 
-        diamond_log = diamond_result_file.parents[0] / f"{diamond_result_file.stem}.log"
+        diamond_log = (
+            diamond_result_file.parents[0]
+            / f"{diamond_result_file.stem.split('.')[0]}.log"
+        )
 
         diamond.run(
             faa_file.as_posix(),
@@ -482,9 +485,9 @@ def main():
 
     use_existing_protein_file = False
 
-    faa_file = out_tmp_dir / "assembly_proteins.faa"
+    faa_file = out_tmp_dir / "assembly_proteins.faa.gz"
 
-    diamond_result_file = out_tmp_dir / "diamond_result.tsv"
+    diamond_result_file = out_tmp_dir / "diamond_result.tsv.gz"
 
     # Output files #
     final_bin_report: Path = args.outdir / "final_bins_quality_reports.tsv"

--- a/binette/main.py
+++ b/binette/main.py
@@ -482,12 +482,7 @@ def main():
 
     use_existing_protein_file = False
 
-    if args.proteins:
-        logging.info(f"Using the provided protein sequences file: {args.proteins}")
-        faa_file = args.proteins
-        use_existing_protein_file = True
-    else:
-        faa_file = out_tmp_dir / "assembly_proteins.faa"
+    faa_file = out_tmp_dir / "assembly_proteins.faa"
 
     diamond_result_file = out_tmp_dir / "diamond_result.tsv"
 
@@ -505,6 +500,16 @@ def main():
         args.contigs,
         fasta_extensions=set(args.fasta_extensions),
     )
+
+    if args.proteins and not args.resume:
+        logging.info(f"Using the provided protein sequences file: {args.proteins}")
+        use_existing_protein_file = True
+
+        cds.filter_faa_file(
+            contigs_in_bins,
+            input_faa_file=args.proteins,
+            filtered_faa_file=faa_file,
+        )
 
     contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
         faa_file=faa_file,

--- a/tests/bin_quality_test.py
+++ b/tests/bin_quality_test.py
@@ -234,6 +234,7 @@ def test_add_bin_metrics(monkeypatch):
             contig_info["contig_to_aa_length"],
             contamination_weight,
             "mock_modelProcessor",  # Mocked postProcessor object
+            chunk_size=1000,
         )
 
 

--- a/tests/cds_test.py
+++ b/tests/cds_test.py
@@ -118,14 +118,14 @@ def test_write_faa(contig1, orf_finder):
 
     predicted_genes = orf_finder.find_genes(contig1.seq)
     contig_name = "contig"
-    output_file = "tests/tmp_file.faa"
+    output_file = "tests/tmp_file.faa.gz"
 
     cds.write_faa(output_file, [(contig_name, predicted_genes)])
 
     # Check if the file was created and first seq starts
     # with the contig name as expected
     assert Path(output_file).exists()
-    with open(output_file, "r") as f:
+    with gzip.open(output_file, "rt") as f:
         assert f.read().startswith(f">{contig_name}")
 
 

--- a/tests/contig_manager_test.py
+++ b/tests/contig_manager_test.py
@@ -4,12 +4,13 @@ import pytest
 
 
 # Parses a valid FASTA file and returns a pyfastx.Fasta object.
-def test_valid_fasta_file():
+def test_valid_fasta_file(tmp_path):
     # Arrange
     fasta_file = "tests/contigs.fasta"
 
-    # Act
-    result = contig_manager.parse_fasta_file(fasta_file)
+    index_file = "tests/contigs.fasta.fxi"
+
+    result = contig_manager.parse_fasta_file(fasta_file, str(index_file))
 
     # Assert
     assert isinstance(result, pyfastx.Fasta)
@@ -22,7 +23,7 @@ def test_invalid_fasta_file():
 
     # Act and Assert
     with pytest.raises(RuntimeError):
-        contig_manager.parse_fasta_file(fasta_file)
+        contig_manager.parse_fasta_file(fasta_file, "./index.fxi")
 
 
 # The function returns a tuple containing two dictionaries.

--- a/tests/diamonds_test.py
+++ b/tests/diamonds_test.py
@@ -155,7 +155,7 @@ def test_run_diamond_tool_found(monkeypatch):
         # Simulating successful run of diamond command
         if (
             args[0]
-            == "diamond blastp --outfmt 6 --max-target-seqs 1 --query test.faa -o output.txt --threads 1 --db db --query-cover 80 --subject-cover 80 --id 30 --evalue 1e-05 --block-size 2 2> log.txt"
+            == "diamond blastp --outfmt 6 --max-target-seqs 1 --query test.faa -o output.txt --threads 1 --db db --compress 1 --query-cover 80 --subject-cover 80 --id 30 --evalue 1e-05 --block-size 2 2> log.txt"
         ):
             return CompletedProcess(0)
 

--- a/tests/main_binette_test.py
+++ b/tests/main_binette_test.py
@@ -136,6 +136,7 @@ def test_manage_protein_alignement_resume(tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file=Path(faa_file),
             contigs_fasta=Path("contigs_fasta"),
+            temporary_dir=Path(tmp_path),
             contig_to_length=contig_to_length,
             contigs_in_bins=set(),
             diamond_result_file=Path("diamond_result_file"),
@@ -179,6 +180,7 @@ def test_manage_protein_alignement_not_resume(tmpdir, tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file=Path(faa_file),
             contigs_fasta=Path(contigs_fasta),
+            temporary_dir=Path(tmp_path),
             contig_to_length=contig_to_length,
             contigs_in_bins=set(),
             diamond_result_file=Path(diamond_result_file),
@@ -208,7 +210,7 @@ def test_parse_input_files_with_contig2bin_tables(tmp_path):
 
     # Call the function and capture the return values
     original_bins, contigs_in_bins, contig_to_length = parse_input_files(
-        None, [bin_set1, bin_set2], fasta_file
+        None, [bin_set1, bin_set2], fasta_file, tmp_path
     )
 
     # # Perform assertions on the returned values
@@ -230,7 +232,7 @@ def test_parse_input_files_with_contig2bin_tables_with_unknown_contig(tmp_path):
     fasta_file.write_text(fasta_file_content)
 
     with pytest.raises(ValueError):
-        parse_input_files(None, [bin_set3], fasta_file)
+        parse_input_files(None, [bin_set3], fasta_file, tmp_path)
 
 
 def test_parse_input_files_bin_dirs(create_temp_bin_directories, tmp_path):
@@ -247,7 +249,7 @@ def test_parse_input_files_bin_dirs(create_temp_bin_directories, tmp_path):
 
     # Call the function and capture the return values
     original_bins, contigs_in_bins, contig_to_length = parse_input_files(
-        bin_dirs, contig2bin_tables, fasta_file
+        bin_dirs, contig2bin_tables, fasta_file, temporary_dir=tmp_path
     )
 
     # # Perform assertions on the returned values
@@ -384,6 +386,7 @@ def test_manage_protein_alignment_no_resume(tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file,
             contigs_fasta,
+            tmp_path,
             contig_to_length,
             contigs_in_bins,
             diamond_result_file,
@@ -395,7 +398,7 @@ def test_manage_protein_alignment_no_resume(tmp_path):
         )
 
         # Assertions to check if functions were called
-        mock_parse_fasta_file.assert_called_once_with(contigs_fasta.as_posix())
+        mock_parse_fasta_file.assert_called_once()
         mock_predict.assert_called_once()
         mock_diamond_get_contig_to_kegg_id.assert_called_once()
         mock_diamond_run.assert_called_once_with(


### PR DESCRIPTION
This PR resolves the issue described in #35, related to how Binette handles proteins given as inputs.

Currently, Binette excludes unbinned contigs to avoid unnecessary computations (e.g., running Prodigal and Diamond on unused contigs). While this saves time, it creates a mismatch when protein files are provided, as unbinned contigs are still present in the protein data. This inconsistency triggers errors during the step that checks for differences between the assembly contigs and the proteins.  

### Solution  

**Filtered Protein File**  
   - The input protein file is now filtered to exclude genes from unbinned contigs.  
   - A filtered version of the file is saved in `<outdir>/temporary_files/` and passed to Diamond for gene annotation.  
   - This ensures only genes from contigs of interest are annotated, resolving the mismatch.  


#### Additional changes 

 **Temporary File Compression**  
   - Temporary files in `<outdir>/temporary_files/`, including the FAA file and Diamond results, are now compressed to save disk space.  
   - The pyfastx index for the contig file is now stored in <outdir>/temporary_files/ instead of alongside the assembly file. This ensures files are written only to the intended directory, avoiding unwanted file placements.
   
   
