### PR TITLE
Fix fasta index

### DIFF
--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -162,7 +162,9 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
         writer.writerows(bin_infos)
 
 
-def write_bins_fasta(selected_bins: List[Bin], contigs_fasta: Path, outdir: Path):
+def write_bins_fasta(
+    selected_bins: List[Bin], contigs_fasta: Path, outdir: Path, index_file: str
+):
     """
     Write selected bins' contigs to separate FASTA files.
 
@@ -171,7 +173,9 @@ def write_bins_fasta(selected_bins: List[Bin], contigs_fasta: Path, outdir: Path
     :param outdir: Output directory to save the individual bin FASTA files.
     """
 
-    fa = pyfastx.Fasta(contigs_fasta.as_posix(), build_index=True)
+    fa = pyfastx.Fasta(
+        contigs_fasta.as_posix(), build_index=True, index_file=index_file
+    )
 
     for sbin in selected_bins:
         outfile = outdir / f"bin_{sbin.id}.fa"

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -163,7 +163,7 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
 
 
 def write_bins_fasta(
-    selected_bins: List[Bin], contigs_fasta: Path, outdir: Path, index_file: str
+    selected_bins: List[Bin], contigs_fasta: Path, outdir: Path, index_file: Path
 ):
     """
     Write selected bins' contigs to separate FASTA files.
@@ -174,7 +174,7 @@ def write_bins_fasta(
     """
 
     fa = pyfastx.Fasta(
-        contigs_fasta.as_posix(), build_index=True, index_file=index_file
+        contigs_fasta.as_posix(), build_index=True, index_file=index_file.as_posix()
     )
 
     for sbin in selected_bins:

--- a/binette/main.py
+++ b/binette/main.py
@@ -417,9 +417,7 @@ def select_bins_and_write_them(
     io.write_bin_info(selected_bins, final_bin_report)
 
     index_file = temporary_dir / f"{contigs_fasta.name}.fxi"
-    io.write_bins_fasta(
-        selected_bins, contigs_fasta, outdir_final_bin_set, index_file.as_posix()
-    )
+    io.write_bins_fasta(selected_bins, contigs_fasta, outdir_final_bin_set, index_file)
 
     if debug:
         all_bin_compo_file = outdir / "all_bins_quality_reports.tsv"

--- a/binette/main.py
+++ b/binette/main.py
@@ -224,6 +224,7 @@ def parse_input_files(
     :param bin_dirs: List of paths to directories containing bin FASTA files.
     :param contig2bin_tables: List of paths to contig-to-bin tables.
     :param contigs_fasta: Path to the contigs FASTA file.
+    :param temporary_dir: Path to the temporary directory to store intermediate files.
     :fasta_extensions: Possible fasta extensions to look for in the bin directory.
 
     :return: A tuple containing:
@@ -295,6 +296,7 @@ def manage_protein_alignement(
 
     :param faa_file: The path to the .faa file.
     :param contigs_fasta: The path to the contigs FASTA file.
+    :param temporary_dir: Path to the temporary directory to store intermediate files.
     :param contig_to_length: Dictionary mapping contig names to their lengths.
     :param contigs_in_bins: Dictionary mapping bin names to lists of contigs.
     :param diamond_result_file: The path to the diamond result file.
@@ -375,6 +377,7 @@ def select_bins_and_write_them(
     min_completeness: float,
     index_to_contig: dict,
     outdir: Path,
+    temporary_dir: Path,
     debug: bool,
 ) -> List[bin_manager.Bin]:
     """
@@ -386,6 +389,7 @@ def select_bins_and_write_them(
     :param min_completeness: Minimum completeness threshold for bin selection.
     :param index_to_contig: Dictionary mapping indices to contig names.
     :param outdir: Output directory to save final bins and reports.
+    :param temporary_dir: Path to the temporary directory to store intermediate files.
     :param debug: Debug mode flag.
     :return: Selected bins that meet the completeness threshold.
     """
@@ -412,7 +416,10 @@ def select_bins_and_write_them(
 
     io.write_bin_info(selected_bins, final_bin_report)
 
-    io.write_bins_fasta(selected_bins, contigs_fasta, outdir_final_bin_set)
+    index_file = temporary_dir / f"{contigs_fasta.name}.fxi"
+    io.write_bins_fasta(
+        selected_bins, contigs_fasta, outdir_final_bin_set, index_file.as_posix()
+    )
 
     if debug:
         all_bin_compo_file = outdir / "all_bins_quality_reports.tsv"
@@ -583,13 +590,14 @@ def main():
     all_bins = original_bins | new_bins
 
     selected_bins = select_bins_and_write_them(
-        all_bins,
-        args.contigs,
-        final_bin_report,
-        args.min_completeness,
-        index_to_contig,
-        args.outdir,
-        args.debug,
+        all_bins=all_bins,
+        contigs_fasta=args.contigs,
+        final_bin_report=final_bin_report,
+        min_completeness=args.min_completeness,
+        index_to_contig=index_to_contig,
+        outdir=args.outdir,
+        temporary_dir=out_tmp_dir,
+        debug=args.debug,
     )
 
     log_selected_bin_info(selected_bins, hq_min_completeness, hq_max_conta)

--- a/tests/io_manager_test.py
+++ b/tests/io_manager_test.py
@@ -256,6 +256,8 @@ def test_write_bin_info_add_contig(tmp_path, bin1, bin2):
 def test_write_bins_fasta(tmp_path, bin1, bin2):
     # Mock input data
     contigs_fasta = tmp_path / "contigs.fasta"
+    index_file = tmp_path / "contigs.fasta.fxi"
+
     contigs_fasta_content = (
         ">contig1\nACGT\n>contig2\nTGCA\n>contig3\nAAAA\n>contig4\nCCCC\n"
     )
@@ -267,7 +269,9 @@ def test_write_bins_fasta(tmp_path, bin1, bin2):
     outdir.mkdir()
 
     # Call the function
-    io_manager.write_bins_fasta(selected_bins, contigs_fasta, outdir)
+    io_manager.write_bins_fasta(
+        selected_bins, contigs_fasta, outdir, index_file=index_file
+    )
 
     # Check if the files were created and their content matches the expected output
     assert (outdir / "bin_1.fa").exists()

--- a/tests/main_binette_test.py
+++ b/tests/main_binette_test.py
@@ -92,6 +92,7 @@ def test_select_bins_and_write_them(tmp_path, tmpdir, bins):
         min_completeness=60,
         index_to_contig=index_to_contig,
         outdir=outdir,
+        temporary_dir=tmp_path,
         debug=True,
     )
 


### PR DESCRIPTION
The pyfastx index for contig file when writting the final bins was not properly set up. 

The index is now the same as when contig are read for the first time: `<outdir>/temporary_files/` . 