### PR TITLE
Improve pyfastx index management

### DIFF
--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov=binette --cov-report=html --cov-report=xml
+        pytest --cov=binette --cov-report=html --cov-report=xml --cov-report=term  -v
 
     - name: Generate coverage badge
       run: |

--- a/.github/workflows/black_lint.yml
+++ b/.github/workflows/black_lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   lint:

--- a/binette/__init__.py
+++ b/binette/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1dev"

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -239,9 +239,7 @@ def get_bins_from_directory(
 
         bin_name = bin_fasta_path.name
 
-        contigs = {
-            name for name, _ in pyfastx.Fasta(str(bin_fasta_path), build_index=False)
-        }
+        contigs = {name for name, _ in pyfastx.Fastx(str(bin_fasta_path))}
 
         bin_obj = Bin(contigs, set_name, bin_name)
 

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -45,7 +45,8 @@ def predict(
 
     with multiprocessing.pool.ThreadPool(processes=threads) as pool:
         contig_and_genes = pool.starmap(
-            predict_genes, ((orf_finder.find_genes, seq) for seq in contigs_iterator)
+            predict_genes,
+            ((orf_finder.find_genes, name, seq) for name, seq in contigs_iterator),
         )
 
     write_faa(outfaa, contig_and_genes)
@@ -58,9 +59,9 @@ def predict(
     return contig_to_genes
 
 
-def predict_genes(find_genes, seq) -> Tuple[str, pyrodigal.Genes]:
+def predict_genes(find_genes, name, seq) -> Tuple[str, pyrodigal.Genes]:
 
-    return (seq.name, find_genes(seq.seq))
+    return (name, find_genes(seq))
 
 
 def write_faa(outfaa: str, contig_to_genes: List[Tuple[str, pyrodigal.Genes]]) -> None:

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -175,7 +175,7 @@ def write_bins_fasta(
     :param temporary_dir: Temporary directory to store the index file.
     """
 
-    index_file = temporary_dir / f"write_final_bins.{contigs_fasta.name}.fxi"
+    index_file = temporary_dir / f"{contigs_fasta.name}.fxi"
 
     fa = contig_manager.parse_fasta_file(
         contigs_fasta.as_posix(), index_file=index_file.as_posix()

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import logging
-import pyfastx
 from typing import Iterable, List, Dict, Tuple, Set
 import csv
 

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -4,6 +4,7 @@ import pyfastx
 from typing import Iterable, List, Dict, Tuple, Set
 import csv
 
+from binette import contig_manager
 from binette.bin_manager import Bin
 
 from pathlib import Path
@@ -163,7 +164,7 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
 
 
 def write_bins_fasta(
-    selected_bins: List[Bin], contigs_fasta: Path, outdir: Path, index_file: Path
+    selected_bins: List[Bin], contigs_fasta: Path, outdir: Path, temporary_dir: Path
 ):
     """
     Write selected bins' contigs to separate FASTA files.
@@ -171,10 +172,13 @@ def write_bins_fasta(
     :param selected_bins: List of Bin objects representing the selected bins.
     :param contigs_fasta: Path to the input FASTA file containing contig sequences.
     :param outdir: Output directory to save the individual bin FASTA files.
+    :param temporary_dir: Temporary directory to store the index file.
     """
 
-    fa = pyfastx.Fasta(
-        contigs_fasta.as_posix(), build_index=True, index_file=index_file.as_posix()
+    index_file = temporary_dir / f"write_final_bins.{contigs_fasta.name}.fxi"
+
+    fa = contig_manager.parse_fasta_file(
+        contigs_fasta.as_posix(), index_file=index_file.as_posix()
     )
 
     for sbin in selected_bins:

--- a/binette/main.py
+++ b/binette/main.py
@@ -25,7 +25,7 @@ from binette import (
 )
 from typing import List, Dict, Optional, Set, Tuple, Union, Sequence, Any
 from pathlib import Path
-
+import pyfastx
 
 def init_logging(verbose, debug):
     """Initialise logging."""
@@ -213,7 +213,6 @@ def parse_input_files(
     bin_dirs: List[Path],
     contig2bin_tables: List[Path],
     contigs_fasta: Path,
-    temporary_dir: Path,
     fasta_extensions: Set[str] = {".fasta", ".fna", ".fa"},
 ) -> Tuple[
     Dict[str, Set[bin_manager.Bin]], Set[bin_manager.Bin], Set[str], Dict[str, int]
@@ -256,13 +255,16 @@ def parse_input_files(
     original_bins = bin_manager.dereplicate_bin_sets(bin_set_name_to_bins.values())
 
     logging.info(f"Parsing contig fasta file: {contigs_fasta}")
-    index_file = temporary_dir / f"{contigs_fasta.name}.fxi"
-    contigs_object = contig_manager.parse_fasta_file(
-        contigs_fasta.as_posix(), index_file=index_file.as_posix()
-    )
 
+    contig_to_length = {
+        name: len(seq)
+        for name, seq in pyfastx.Fastx(contigs_fasta.as_posix())
+        if name in contigs_in_bins
+    }
+
+    # check if all contigs from input bins are present in contigs file
     unexpected_contigs = {
-        contig for contig in contigs_in_bins if contig not in contigs_object
+        contig for contig in contigs_in_bins if contig not in contig_to_length
     }
 
     if len(unexpected_contigs):
@@ -271,17 +273,12 @@ def parse_input_files(
             f"The missing contigs are: {', '.join(unexpected_contigs)}. Please ensure all contigs from input bins are present in contig file."
         )
 
-    contig_to_length = {
-        seq.name: len(seq) for seq in contigs_object if seq.name in contigs_in_bins
-    }
-
     return original_bins, contigs_in_bins, contig_to_length
 
 
 def manage_protein_alignement(
     faa_file: Path,
     contigs_fasta: Path,
-    temporary_dir: Path,
     contig_to_length: Dict[str, int],
     contigs_in_bins: Set[str],
     diamond_result_file: Path,
@@ -296,7 +293,6 @@ def manage_protein_alignement(
 
     :param faa_file: The path to the .faa file.
     :param contigs_fasta: The path to the contigs FASTA file.
-    :param temporary_dir: Path to the temporary directory to store intermediate files.
     :param contig_to_length: Dictionary mapping contig names to their lengths.
     :param contigs_in_bins: Dictionary mapping bin names to lists of contigs.
     :param diamond_result_file: The path to the diamond result file.
@@ -321,13 +317,10 @@ def manage_protein_alignement(
         )
 
     else:
-        index_file = temporary_dir / f"{contigs_fasta.name}.fxi"
         contigs_iterator = (
-            seq
-            for seq in contig_manager.parse_fasta_file(
-                contigs_fasta.as_posix(), index_file=index_file.as_posix()
-            )
-            if seq.name in contigs_in_bins
+            (name, seq)
+            for name, seq in pyfastx.Fastx(contigs_fasta.as_posix())
+            if name in contigs_in_bins
         )
         contig_to_genes = cds.predict(contigs_iterator, faa_file.as_posix(), threads)
 
@@ -416,8 +409,9 @@ def select_bins_and_write_them(
 
     io.write_bin_info(selected_bins, final_bin_report)
 
-    index_file = temporary_dir / f"{contigs_fasta.name}.fxi"
-    io.write_bins_fasta(selected_bins, contigs_fasta, outdir_final_bin_set, index_file)
+    io.write_bins_fasta(
+        selected_bins, contigs_fasta, outdir_final_bin_set, temporary_dir
+    )
 
     if debug:
         all_bin_compo_file = outdir / "all_bins_quality_reports.tsv"
@@ -514,7 +508,6 @@ def main():
         args.contig2bin_tables,
         args.contigs,
         fasta_extensions=set(args.fasta_extensions),
-        temporary_dir=out_tmp_dir,
     )
 
     if args.proteins and not args.resume:
@@ -530,7 +523,6 @@ def main():
     contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
         faa_file=faa_file,
         contigs_fasta=args.contigs,
-        temporary_dir=out_tmp_dir,
         contig_to_length=contig_to_length,
         contigs_in_bins=contigs_in_bins,
         diamond_result_file=diamond_result_file,

--- a/binette/main.py
+++ b/binette/main.py
@@ -27,6 +27,7 @@ from typing import List, Dict, Optional, Set, Tuple, Union, Sequence, Any
 from pathlib import Path
 import pyfastx
 
+
 def init_logging(verbose, debug):
     """Initialise logging."""
     if debug:

--- a/tests/cds_test.py
+++ b/tests/cds_test.py
@@ -104,6 +104,7 @@ def test_extract_contig_name_from_cds_name():
     assert isinstance(result, str)
     assert result == "contig1"
 
+
 def test_write_faa(contig1, orf_finder):
     name, seq = contig1
     predicted_genes = orf_finder.find_genes(seq)

--- a/tests/cds_test.py
+++ b/tests/cds_test.py
@@ -20,7 +20,7 @@ def contig1():
         name="contig1",
         seq="ATGAGCATCAGGGGAGTAGGAGGATGCAACGGGAATAGTCGAATCCCTTCTCATAATGGGGATGGATCGAATCGCAGAAGTCAAAATACGAAGGGTAATAATAAAGTTGAAGATCGAGTTTGT",
     )
-    return contig
+    return contig.name, contig.seq
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def contig2():
         name="contig2",
         seq="TTGGTCGTATGACTGATAATTTCTCAGACATTGAAAACTTTAATGAAATTTTCAACAGAAAACCTGCTTTACAATTTCGTTTTTA",
     )
-    return contig
+    return contig.name, contig.seq
 
 
 @pytest.fixture
@@ -85,13 +85,13 @@ def test_predict_orf_with_multiple_threads(contig1, contig2):
 
 
 def test_predict_genes(contig1, orf_finder):
-
-    result = cds.predict_genes(orf_finder.find_genes, contig1)
+    name, seq = contig1
+    result = cds.predict_genes(orf_finder.find_genes, name, seq)
 
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert isinstance(result[0], str)
-    assert result[0] == contig1.name
+    assert result[0] == name
     assert result[0] == "contig1"
 
 
@@ -115,8 +115,8 @@ def test_extract_contig_name_from_cds_name():
 
 
 def test_write_faa(contig1, orf_finder):
-
-    predicted_genes = orf_finder.find_genes(contig1.seq)
+    name, seq = contig1
+    predicted_genes = orf_finder.find_genes(seq)
     contig_name = "contig"
     output_file = "tests/tmp_file.faa.gz"
 

--- a/tests/cds_test.py
+++ b/tests/cds_test.py
@@ -104,16 +104,6 @@ def test_extract_contig_name_from_cds_name():
     assert isinstance(result, str)
     assert result == "contig1"
 
-
-def test_extract_contig_name_from_cds_name():
-    cds_name = "contig1_gene1"
-
-    result = cds.get_contig_from_cds_name(cds_name)
-
-    assert isinstance(result, str)
-    assert result == "contig1"
-
-
 def test_write_faa(contig1, orf_finder):
     name, seq = contig1
     predicted_genes = orf_finder.find_genes(seq)

--- a/tests/contig_manager_test.py
+++ b/tests/contig_manager_test.py
@@ -8,8 +8,7 @@ def test_valid_fasta_file(tmp_path):
     # Arrange
     fasta_file = "tests/contigs.fasta"
 
-    index_file = "tests/contigs.fasta.fxi"
-
+    index_file = tmp_path / "contigs.fasta.fxi"
     result = contig_manager.parse_fasta_file(fasta_file, str(index_file))
 
     # Assert

--- a/tests/io_manager_test.py
+++ b/tests/io_manager_test.py
@@ -256,7 +256,6 @@ def test_write_bin_info_add_contig(tmp_path, bin1, bin2):
 def test_write_bins_fasta(tmp_path, bin1, bin2):
     # Mock input data
     contigs_fasta = tmp_path / "contigs.fasta"
-    index_file = tmp_path / "contigs.fasta.fxi"
 
     contigs_fasta_content = (
         ">contig1\nACGT\n>contig2\nTGCA\n>contig3\nAAAA\n>contig4\nCCCC\n"
@@ -269,9 +268,7 @@ def test_write_bins_fasta(tmp_path, bin1, bin2):
     outdir.mkdir()
 
     # Call the function
-    io_manager.write_bins_fasta(
-        selected_bins, contigs_fasta, outdir, index_file=index_file
-    )
+    io_manager.write_bins_fasta(selected_bins, contigs_fasta, outdir, tmp_path)
 
     # Check if the files were created and their content matches the expected output
     assert (outdir / "bin_1.fa").exists()

--- a/tests/main_binette_test.py
+++ b/tests/main_binette_test.py
@@ -137,7 +137,6 @@ def test_manage_protein_alignement_resume(tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file=Path(faa_file),
             contigs_fasta=Path("contigs_fasta"),
-            temporary_dir=Path(tmp_path),
             contig_to_length=contig_to_length,
             contigs_in_bins=set(),
             diamond_result_file=Path("diamond_result_file"),
@@ -182,7 +181,6 @@ def test_manage_protein_alignement_not_resume(tmpdir, tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file=Path(faa_file),
             contigs_fasta=Path(contigs_fasta),
-            temporary_dir=Path(tmp_path),
             contig_to_length=contig_to_length,
             contigs_in_bins=set(),
             diamond_result_file=Path(diamond_result_file),
@@ -251,7 +249,7 @@ def test_parse_input_files_bin_dirs(create_temp_bin_directories, tmp_path):
 
     # Call the function and capture the return values
     original_bins, contigs_in_bins, contig_to_length = parse_input_files(
-        bin_dirs, contig2bin_tables, fasta_file, temporary_dir=tmp_path
+        bin_dirs, contig2bin_tables, fasta_file
     )
 
     # # Perform assertions on the returned values
@@ -371,7 +369,7 @@ def test_manage_protein_alignment_no_resume(tmp_path):
 
     # Mock the necessary functions
     with (
-        patch("binette.contig_manager.parse_fasta_file") as mock_parse_fasta_file,
+        patch("pyfastx.Fastx") as mock_pyfastx_Fastx,
         patch("binette.cds.predict") as mock_predict,
         patch("binette.diamond.get_checkm2_db") as mock_get_checkm2_db,
         patch("binette.diamond.run") as mock_diamond_run,
@@ -381,14 +379,13 @@ def test_manage_protein_alignment_no_resume(tmp_path):
     ):
 
         # Set the return value of the mocked functions
-        mock_parse_fasta_file.return_value = [MagicMock(name="contig1")]
+        mock_pyfastx_Fastx.return_value = [("contig1", "ATCG")]
         mock_predict.return_value = {"contig1": ["gene1"]}
 
         # Call the function
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file,
             contigs_fasta,
-            tmp_path,
             contig_to_length,
             contigs_in_bins,
             diamond_result_file,
@@ -400,7 +397,7 @@ def test_manage_protein_alignment_no_resume(tmp_path):
         )
 
         # Assertions to check if functions were called
-        mock_parse_fasta_file.assert_called_once()
+        mock_pyfastx_Fastx.assert_called_once()
         mock_predict.assert_called_once()
         mock_diamond_get_contig_to_kegg_id.assert_called_once()
         mock_diamond_run.assert_called_once_with(


### PR DESCRIPTION
This PR attempts to fix the error related to pyfastx, as reported in issue #49.

To resolve the issue, the approach has been modified:
- pyfastx.Fasta which produce the fasta file index, is now used only when writing the final bin.
- pyfastx.Fastx is used for protein prediction and initial contig parsing to avoid multiple accesses to the index file.