### PR TITLE
Sort bins to make Binette reproductible

### DIFF
--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -383,9 +383,9 @@ def get_all_possible_combinations(clique: List) -> Iterable[Tuple]:
 
 def get_intersection_bins(cliques: List[List[Bin]]) -> Set[Bin]:
     """
-    Retrieves the intersection bins from a given graph.
+    Retrieves the intersection bins from a given list of cliques.
 
-    :param G: A networkx Graph representing the graph.
+    :param cliques: A list of cliques.
 
     :return: A set of Bin objects representing the intersection bins.
     """
@@ -413,7 +413,7 @@ def get_difference_bins(cliques: List[List[Bin]]) -> Set[Bin]:
     """
     Retrieves the difference bins from a given graph.
 
-    :param G: A networkx Graph representing the graph.
+    :param cliques: A list of cliques.
 
     :return: A set of Bin objects representing the difference bins.
     """
@@ -440,8 +440,7 @@ def get_union_bins(cliques: List[List[Bin]]) -> Set[Bin]:
     """
     Retrieves the union bins from a given graph.
 
-    :param G: A networkx Graph representing the graph of bins.
-    :param max_conta: Maximum allowed contamination value for a bin to be included in the union.
+    :param cliques: A list of cliques.
 
     :return: A set of Bin objects representing the union bins.
     """

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -188,7 +188,7 @@ def add_bin_metrics(
 
     add_bin_size_and_N50(bins, contig_to_length)
 
-    logging.info(f"Assessing bin quality for {len(bins)}")
+    logging.info(f"Assessing bin quality for {len(bins)} bins.")
     assess_bins_quality_by_chunk(
         bins,
         contig_to_kegg_counter,

--- a/tests/bin_manager_test.py
+++ b/tests/bin_manager_test.py
@@ -374,7 +374,9 @@ def simple_bin_graph():
 
 def test_get_intersection_bins(simple_bin_graph):
 
-    intersec_bins = bin_manager.get_intersection_bins(simple_bin_graph)
+    intersec_bins = bin_manager.get_intersection_bins(
+        list(nx.clique.find_cliques(simple_bin_graph))
+    )
 
     assert len(intersec_bins) == 1
     intersec_bin = intersec_bins.pop()
@@ -384,7 +386,9 @@ def test_get_intersection_bins(simple_bin_graph):
 
 def test_get_difference_bins(simple_bin_graph):
 
-    difference_bins = bin_manager.get_difference_bins(simple_bin_graph)
+    difference_bins = bin_manager.get_difference_bins(
+        list(nx.clique.find_cliques(simple_bin_graph))
+    )
 
     expected_bin1 = bin_manager.Bin(contigs={"3"}, origin="D", name="1")
     expected_bin2 = bin_manager.Bin(contigs={"4"}, origin="D", name="2")
@@ -395,7 +399,7 @@ def test_get_difference_bins(simple_bin_graph):
 
 def test_get_union_bins(simple_bin_graph):
 
-    u_bins = bin_manager.get_union_bins(simple_bin_graph)
+    u_bins = bin_manager.get_union_bins(list(nx.clique.find_cliques(simple_bin_graph)))
 
     expected_bin1 = bin_manager.Bin(contigs={"1", "2", "3", "4"}, origin="U", name="1")
 


### PR DESCRIPTION
Small change in the code to sort bins when creating intermediate bins to ensure they have a consistent ids across executions to prevent output from changing between different executions.
Should fix issue #54