### PR TITLE
Bitmap storage, faster CheckM2, and smarter bin filtering

### DIFF
--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Compare results from bin2table with expectation
       run: |
         cd test_data
-        head  expected_results/final_bins_quality_reports.tsv test_results/final_bins_quality_reports.tsv
+        head  ../tests/expected_results/final_bins_quality_reports.tsv test_results/final_bins_quality_reports.tsv
         python scripts/compare_results.py ../tests/expected_results/final_bins_quality_reports.tsv test_results/final_bins_quality_reports.tsv
 
 
@@ -92,7 +92,7 @@ jobs:
     - name: Compare results from bin dirs with expectation
       run: |
         cd test_data
-        head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
+        head  ../tests/expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
         python scripts/compare_results.py ../tests/expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
 
 
@@ -105,7 +105,7 @@ jobs:
     - name: Compare results from bin dirs with expectation
       run: |
         cd test_data
-        head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
+        head  ../tests/expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
         python scripts/compare_results.py ../tests/expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
 
 

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -81,7 +81,7 @@ jobs:
       run: |
         cd test_data
         head  expected_results/final_bins_quality_reports.tsv test_results/final_bins_quality_reports.tsv
-        python scripts/compare_results.py expected_results/final_bins_quality_reports.tsv test_results/final_bins_quality_reports.tsv
+        python scripts/compare_results.py ../tests/expected_results/final_bins_quality_reports.tsv test_results/final_bins_quality_reports.tsv
 
 
     - name: Run simple test case from bin dirs
@@ -93,7 +93,7 @@ jobs:
       run: |
         cd test_data
         head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
-        python scripts/compare_results.py expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
+        python scripts/compare_results.py ../tests/expected_results/final_bins_quality_reports.tsv test_results_from_dirs/final_bins_quality_reports.tsv
 
 
     - name: Run simple test case from bin dirs and with proteins input
@@ -106,6 +106,6 @@ jobs:
       run: |
         cd test_data
         head  expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
-        python scripts/compare_results.py expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
+        python scripts/compare_results.py ../tests/expected_results/final_bins_quality_reports.tsv test_results_from_dirs_and_prot_input/final_bins_quality_reports.tsv
 
 

--- a/README.md
+++ b/README.md
@@ -173,17 +173,19 @@ In this directory you will find:
 
 
 The `final_bins_quality_reports.tsv` file contains the following columns:
-| Column Name         | Description                                                                                                  |
-|---------------------|--------------------------------------------------------------------------------------------------------------|
-| **bin_id**          | This column displays the unique ID of the bin.                                                             |
-| **origin**          | Indicates the source or origin of the bin, specifying from which bin set it originates or the intermediate set operation that created it. |
-| **name**            | The name of the bin.                                                                                        |
-| **completeness**    | The completeness of the bin, determined by CheckM2.                                                         |
-| **contamination**   | The contamination of the bin, determined by CheckM2.                                                       |
-| **score**           | This column displays the computed score, which is calculated as: `completeness - contamination * weight`. You can customize the contamination weight using the `--contamination_weight` option. |
-| **size**            | Represents the size of the bin in nucleotides.                                                              |
-| **N50**             | Displays the N50 of the bin.                                                                                |
-| **contig_count**    | The number of contigs contained within the bin.                                                             |
+| Column Name        | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **name**           | The unique name of the bin.                                                                                                                    |
+| **origin**         | Indicates the source of the bin: either an original bin set (e.g., `B`) or `binette` for intermediate bins.                                    |
+| **is\_original**   | Boolean flag indicating if the bin is an original bin (`True`) or an intermediate bin (`False`).                                               |
+| **original\_name** | The name of the original bin from which this bin was derived.                                                                                  |
+| **completeness**   | The completeness of the bin, determined by CheckM2.                                                                                            |
+| **contamination**  | The contamination of the bin, determined by CheckM2.                                                                                           |
+| **score**          | Computed score: `completeness - contamination * weight`. The contamination weight can be customized using the `--contamination_weight` option. |
+| **size**           | Total size of the bin in nucleotides.                                                                                                          |
+| **N50**            | The N50 of the bin, representing the length for which 50% of the total nucleotides are in contigs of that length or longer.                    |
+| **contig\_count**  | Number of contigs contained within the bin.                                                                                                    |
+
 
 ## Help, feature requests and bug reporting
 

--- a/binette.yaml
+++ b/binette.yaml
@@ -15,3 +15,4 @@ dependencies:
   - networkx>=3.0,<4.0
   - pyfastx>=2,<4
   - pyrodigal
+  - pyroaring>=1.0,<2.0

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from collections import Counter
 from pyroaring import BitMap
 from functools import cached_property
-
+import numpy as np
 
 class Bin:
 
@@ -526,7 +526,38 @@ def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> List[s
     return list(all_contigs_in_bins)
 
 
-def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
+def get_contigs_in_bins(bins: Iterable[Bin]) -> List[str]:
+    """
+    Retrieves all contigs present in the given list of bins.
+
+    :param bins: A list of Bin objects.
+
+    :return: A list of contigs present in the bins.
+    """
+    return [contig for b in bins for contig in b.contigs]
+
+
+def sum_contig_lengths(
+    bm_contigs: BitMap,
+    contig_lengths: np.ndarray,
+    cache: Dict[bytes, int] = {},
+    key: Optional[bytes] = None,
+):
+    if key is None:
+        key = bm_contigs.serialize()
+    if key not in cache:
+        cache[key] = int(contig_lengths[np.fromiter(bm_contigs, dtype=np.int32)].sum())
+    return cache[key]
+
+
+def create_intermediate_bins(
+    contig_key_to_initial_bin: Dict[bytes, Bin],
+    contig_lengths: np.ndarray,
+    min_comp: float,
+    max_conta: float,
+    min_len: int,
+    max_len: int,
+) -> Dict[bytes, Bin]:
     """
     Creates intermediate bins from a dictionary of bin sets.
 
@@ -534,11 +565,7 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
 
     :return: A set of intermediate bins created from intersections, differences, and unions.
     """
-    min_comp = 40
-    max_conta = 20
-
-    min_len = 500_000
-    max_len = 6_000_000
+    bin_length_cache = {}
 
     logging.info("Making bin graph...")
     connected_bins_graph = from_bins_to_bin_graph(contig_key_to_initial_bin.values())
@@ -548,11 +575,25 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
     )
 
     logging.info("Creating union, difference, and intersection bins...")
-
+    logging.debug(f"{min_comp} min completeness for intersection and difference bins.")
+    logging.debug(
+        f"{max_conta} max contamination for intersection and difference bins."
+    )
+    logging.debug(f"{min_len} min length for intersection and difference bins.")
+    logging.debug(f"{max_len} max length for intersection and difference bins.")
+    logging.info(
+        f"Intermediate bins filtered by minimum length of {min_len} and maximum length of {max_len}."
+    )
     intersec_count = 0
     union_count = 0
     diff_count = 0
+
+    intersec_size_discarded_count = 0
+    diff_size_discarded_count = 0
+    union_size_discarded_count = 0
+
     contig_key_to_new_contigs_set = {}
+    discarded_contig_set_keys = set()
     for clique in tqdm(
         cliques_of_bins, total=len(cliques_of_bins), unit="clique of bins"
     ):
@@ -562,21 +603,34 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
 
             bins = [contig_key_to_initial_bin[ck] for ck in bin_contig_keys]
 
-            if all(b.completeness >= min_comp for b in bins):
+            if all(b.completeness >= min_comp and b.length >= min_len for b in bins):
 
                 intersec_contigs = bins[0].contig_intersection(*bins[1:])
 
                 if intersec_contigs:
                     contig_key = intersec_contigs.serialize()
+
                     if (
                         contig_key not in contig_key_to_initial_bin
                         and contig_key not in contig_key_to_new_contigs_set
+                        and contig_key not in discarded_contig_set_keys
                     ):
-                        contig_key_to_new_contigs_set[contig_key] = intersec_contigs
-                        intersec_count += 1
+                        contigs_length = sum_contig_lengths(
+                            intersec_contigs,
+                            contig_lengths,
+                            cache=bin_length_cache,
+                            key=contig_key,
+                        )
+
+                        if contigs_length >= min_len and contigs_length <= max_len:
+                            contig_key_to_new_contigs_set[contig_key] = intersec_contigs
+                            intersec_count += 1
+                        else:
+                            discarded_contig_set_keys.add(contig_key)
+                            intersec_size_discarded_count += 1
 
             for bin_a in bins:
-                if bin_a.completeness >= min_comp:
+                if bin_a.completeness >= min_comp and bin_a.length >= min_len:
 
                     diff_contigs = bin_a.contig_difference(
                         *(b for b in bins if b != bin_a)
@@ -588,11 +642,23 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
                         if (
                             contig_key not in contig_key_to_initial_bin
                             and contig_key not in contig_key_to_new_contigs_set
+                            and contig_key not in discarded_contig_set_keys
                         ):
-                            contig_key_to_new_contigs_set[contig_key] = diff_contigs
-                            diff_count += 1
+                            contigs_length = sum_contig_lengths(
+                                diff_contigs,
+                                contig_lengths,
+                                cache=bin_length_cache,
+                                key=contig_key,
+                            )
 
-            if all(b.contamination <= max_conta for b in bins):
+                            if contigs_length >= min_len and contigs_length <= max_len:
+                                contig_key_to_new_contigs_set[contig_key] = diff_contigs
+                                diff_count += 1
+                            else:
+                                discarded_contig_set_keys.add(contig_key)
+                                diff_size_discarded_count += 1
+
+            if all(b.contamination <= max_conta and b.length <= max_len for b in bins):
 
                 union_contigs = bins[0].contig_union(*bins[1:])
                 if union_contigs:
@@ -600,15 +666,32 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
                     if (
                         contig_key not in contig_key_to_initial_bin
                         and contig_key not in contig_key_to_new_contigs_set
+                        and contig_key not in discarded_contig_set_keys
                     ):
-                        contig_key_to_new_contigs_set[contig_key] = union_contigs
-                        union_count += 1
+                        contigs_length = sum_contig_lengths(
+                            union_contigs,
+                            contig_lengths,
+                            cache=bin_length_cache,
+                            key=contig_key,
+                        )
+                        if contigs_length >= min_len and contigs_length <= max_len:
+                            contig_key_to_new_contigs_set[contig_key] = union_contigs
+                            union_count += 1
+                        else:
+                            discarded_contig_set_keys.add(contig_key)
+                            union_size_discarded_count += 1
 
-    logging.info(f"{intersec_count} bins created on intersections.")
+    logging.info(
+        f"Intersection: {intersec_count} bins created, {intersec_size_discarded_count} discarded due to size constraints."
+    )
 
-    logging.info(f"{diff_count} bins created based on symmetric difference.")
+    logging.info(
+        f"Symmetric Difference: {diff_count} bins created, {diff_size_discarded_count} discarded due to size constraints."
+    )
 
-    logging.info(f"{union_count} bins created on unions.")
+    logging.info(
+        f"Union: {union_count} bins created, {union_size_discarded_count} discarded due to size constraints."
+    )
 
     contig_key_to_new_bin: Dict[bytes, Bin] = {
         contig_key: Bin(contigs, is_original=False)

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -701,7 +701,7 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
 
             bins = [contig_key_to_initial_bin[ck] for ck in bin_contig_keys]
 
-            if all((b.completeness for b in bins)) > min_comp:
+            if all(b.completeness >= min_comp for b in bins):
 
                 intersec_contigs = bins[0].contig_intersection(*bins[1:])
 
@@ -731,7 +731,7 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
                             contig_key_to_new_contigs_set[contig_key] = diff_contigs
                             diff_count += 1
 
-            if all((b.contamination for b in bins)) <= max_conta:
+            if all(b.contamination <= max_conta for b in bins):
 
                 union_contigs = bins[0].contig_union(*bins[1:])
                 if union_contigs:

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -6,18 +6,22 @@ import pyfastx
 
 import itertools
 import networkx as nx
-from typing import List, Dict, Iterable, Tuple, Set
+from typing import Any, List, Dict, Iterable, Tuple, Set, Optional
 from tqdm import tqdm
 
 from collections import Counter
 from pyroaring import BitMap
+from functools import cached_property
 
 
 class Bin:
-    counter = 0
 
     def __init__(
-        self, contigs: Iterable[str], origin: str, name: str, is_original: bool = False
+        self,
+        contigs: BitMap,
+        origin: Optional[Set[str]] = None,
+        name: Optional[str] = None,
+        is_original: bool = False,
     ) -> None:
         """
         Initialize a Bin object.
@@ -26,18 +30,20 @@ class Bin:
         :param origin: Origin/source of the bin.
         :param name: Name of the bin.
         """
-        Bin.counter += 1
 
-        self.origin = {origin}
-        self.name = name
-        self.id = Bin.counter
-        # check contigs type
-        if isinstance(contigs, BitMap):
-            self.contigs = contigs
+        if not isinstance(contigs, BitMap):
+            raise TypeError("Contigs should be a BitMap object.")
+
+        if origin is None:
+            self.origin = set()
         else:
-            self.contigs = set(contigs)
+            self.origin = {origin}
 
-        self.hash = hash(str(sorted(self.contigs)))
+        self.name = name
+
+        self.is_original = is_original
+
+        self.contigs = contigs
 
         self.length = None
         self.N50 = None
@@ -45,8 +51,14 @@ class Bin:
         self.completeness = None
         self.contamination = None
         self.score = None
+        self.original_name = None
 
-        self.is_original = is_original
+    @cached_property
+    def contigs_key(self):
+        """
+        Serialize the contigs for easier comparison.
+        """
+        return self.contigs.serialize()
 
     def __eq__(self, other: "Bin") -> bool:
         """
@@ -55,15 +67,11 @@ class Bin:
         :param other: The object to compare with.
         :return: True if the objects are equal, False otherwise.
         """
-        return self.contigs == other.contigs
 
-    def __hash__(self) -> int:
-        """
-        Compute the hash value of the Bin object.
+        if not isinstance(other, Bin):
+            return NotImplemented
 
-        :return: The hash value.
-        """
-        return self.hash
+        return self.contigs_key == other.contigs_key
 
     def __str__(self) -> str:
         """
@@ -71,19 +79,7 @@ class Bin:
 
         :return: The string representation of the Bin object.
         """
-        return (
-            f"Bin {self.id} from {';'.join(self.origin)}  ({len(self.contigs)} contigs)"
-        )
-
-    def __lt__(self, other: "Bin") -> bool:
-        """
-        Compare the Bin object with another object based on their id. This is useful to be able to sort the bins.
-
-        :param other: The object to compare with.
-        :return: True if self has an id lower than the other bin.
-        """
-
-        return self.id < other.id
+        return f"Bin {self.name} from {';'.join(self.origin)}  ({len(self.contigs)} contigs)"
 
     def overlaps_with(self, other: "Bin") -> Set[str]:
         """
@@ -132,67 +128,29 @@ class Bin:
         self.contamination = contamination
         self.score = completeness - contamination_weight * contamination
 
-    # def intersection(self, *others: "Bin") -> "Bin":
-    #     """
-    #     Compute the intersection of the bin with other bins.
-
-    #     :param others: Other bins to compute the intersection with.
-    #     :return: A new Bin representing the intersection of the bins.
-    #     """
-    #     other_contigs = (o.contigs for o in others)
-    #     contigs = self.contigs.intersection(*other_contigs)
-    #     name = f"{self.id} & {' & '.join([str(other.id) for other in sorted(others)])}"
-    #     origin = "intersec"
-
-    #     return Bin(contigs, origin, name)
-
-    # def difference(self, *others: "Bin") -> "Bin":
-    #     """
-    #     Compute the difference between the bin and other bins.
-
-    #     :param others: Other bins to compute the difference with.
-    #     :return: A new Bin representing the difference between the bins.
-    #     """
-    #     other_contigs = (o.contigs for o in others)
-    #     contigs = self.contigs.difference(*other_contigs)
-    #     name = f"{self.id} - {' - '.join([str(other.id) for other in sorted(others)])}"
-    #     origin = "diff"
-
-    #     return Bin(contigs, origin, name)
-
-    # def union(self, *others: "Bin") -> "Bin":
-    #     """
-    #     Compute the union of the bin with other bins.
-
-    #     :param others: Other bins to compute the union with.
-    #     :return: A new Bin representing the union of the bins.
-    #     """
-    #     other_contigs = (o.contigs for o in others)
-    #     contigs = self.contigs.union(*other_contigs)
-    #     name = f"{self.id} | {' | '.join([str(other.id) for other in sorted(others)])}"
-
-    #     origin = "union"
-
-    #     return Bin(contigs, origin, name)
-
-    def is_complete_enough(self, min_completeness: float) -> bool:
+    def contig_intersection(self, *others: "Bin") -> BitMap:
         """
-        Determine if a bin is complete enough based on completeness threshold.
+        Compute the intersection of the bin with other bins.
 
-        :param min_completeness: The minimum completeness required for a bin.
-
-        :raises ValueError: If completeness has not been set (is None).
-
-        :return: True if the bin meets the min_completeness threshold; False otherwise.
+        :param others: Other bins to compute the intersection with.
         """
+        return self.contigs.intersection(*(o.contigs for o in others))
 
-        if self.completeness is None:
-            raise ValueError(
-                f"The bin '{self.name}' with ID '{self.id}' has not been evaluated for completeness or contamination, "
-                "and therefore cannot be assessed."
-            )
+    def contig_difference(self, *others: "Bin") -> BitMap:
+        """
+        Compute the difference between the bin and other bins.
 
-        return self.completeness >= min_completeness
+        :param others: Other bins to compute the difference with.
+        """
+        return self.contigs.difference(*(o.contigs for o in others))
+
+    def contig_union(self, *others: "Bin") -> BitMap:
+        """
+        Compute the union of the bin with other bins.
+
+        :param others: Other bins to compute the union with.
+        """
+        return self.contigs.union(*(o.contigs for o in others))
 
     def is_high_quality(
         self, min_completeness: float, max_contamination: float
@@ -217,6 +175,44 @@ class Bin:
             self.completeness >= min_completeness
             and self.contamination <= max_contamination
         )
+
+
+def make_bins_from_bins_info(
+    bin_set_name_to_bins_info: Dict[str, List[Dict[str, Any]]],
+    contig_to_index: Dict[str, int],
+    are_original_bins: bool,
+):
+    """
+    Create Bin objects from the provided bin information.
+
+    :param bin_set_name_to_bins_info: A dictionary mapping bin set names to their bin information.
+    :param contig_to_index: A mapping of contig names to their indices.
+    :param are_original_bins: A boolean indicating whether the bins are original.
+
+    :return: A dictionary mapping serialized contig bitmaps to their corresponding Bin objects.
+    """
+
+    contig_key_to_bin: Dict[bytes, Bin] = {}
+
+    for set_name, bins_info in bin_set_name_to_bins_info.items():
+
+        for bin_info in bins_info:
+            bitmap_contigs = BitMap(
+                (contig_to_index[contig] for contig in bin_info["contigs"])
+            )
+
+            bin_obj = Bin(
+                contigs=bitmap_contigs,
+                origin=set_name,
+                name=bin_info["bin_name"],
+                is_original=are_original_bins,
+            )
+            if bin_obj.contigs_key not in contig_key_to_bin:
+                contig_key_to_bin[bin_obj.contigs_key] = bin_obj
+            else:
+                bin_obj.origin.add(set_name)
+
+    return contig_key_to_bin
 
 
 def get_bins_from_directory(
@@ -247,16 +243,16 @@ def get_bins_from_directory(
 
         contigs = {name for name, _ in pyfastx.Fastx(str(bin_fasta_path))}
 
-        bin_obj = Bin(contigs, set_name, bin_name)
+        bin_dict = {"contigs": contigs, "set_name": set_name, "bin_name": bin_name}
 
-        bins.append(bin_obj)
+        bins.append(bin_dict)
 
     return bins
 
 
 def parse_bin_directories(
     bin_name_to_bin_dir: Dict[str, Path], fasta_extensions: Set[str]
-) -> Dict[str, Set[Bin]]:
+) -> Dict[str, List[Dict[str, Any]]]:
     """
     Parses multiple bin directories and returns a dictionary mapping bin names to a list of Bin objects.
 
@@ -265,30 +261,32 @@ def parse_bin_directories(
 
     :return: A dictionary mapping bin names to a list of Bin objects created from the bin directories.
     """
-    bin_set_name_to_bins = {}
+    bin_set_name_to_bins_info = {}
 
     for name, bin_dir in sorted(bin_name_to_bin_dir.items()):
         bins = get_bins_from_directory(bin_dir, name, fasta_extensions)
-        set_of_bins = set(bins)
 
-        # Calculate the number of duplicates
-        num_duplicates = len(bins) - len(set_of_bins)
+        # TODO: redo this check
+        # set_of_bins = set(bins)
 
-        if num_duplicates > 0:
-            logging.warning(
-                f'{num_duplicates} bins with identical contig compositions detected in bin set "{name}". '
-                "These bins were merged to ensure uniqueness."
-            )
+        # # Calculate the number of duplicates
+        # num_duplicates = len(bins) - len(set_of_bins)
+
+        # if num_duplicates > 0:
+        #     logging.warning(
+        #         f'{num_duplicates} bins with identical contig compositions detected in bin set "{name}". '
+        #         "These bins were merged to ensure uniqueness."
+        #     )
 
         # Store the unique set of bins
-        bin_set_name_to_bins[name] = set_of_bins
+        bin_set_name_to_bins_info[name] = bins
 
-    return bin_set_name_to_bins
+    return bin_set_name_to_bins_info
 
 
 def parse_contig2bin_tables(
     bin_name_to_bin_tables: Dict[str, Path],
-) -> Dict[str, Set["Bin"]]:
+) -> Dict[str, List[Dict[str, Any]]]:
     """
     Parses multiple contig-to-bin tables and returns a dictionary mapping bin names to a set of unique Bin objects.
 
@@ -300,25 +298,27 @@ def parse_contig2bin_tables(
     :return: A dictionary where keys are bin set names and values are sets of Bin objects. Duplicates are removed based
              on contig composition.
     """
-    bin_set_name_to_bins = {}
+    bin_set_name_to_bins_info = {}
 
     for name, contig2bin_table in sorted(bin_name_to_bin_tables.items()):
         bins = get_bins_from_contig2bin_table(contig2bin_table, name)
-        set_of_bins = set(bins)
 
-        # Calculate the number of duplicates
-        num_duplicates = len(bins) - len(set_of_bins)
+        # TODO: redo this check
+        # set_of_bins = set(bins)
 
-        if num_duplicates > 0:
-            logging.warning(
-                f'{num_duplicates*2} bins with identical contig compositions detected in bin set "{name}". '
-                "These bins were merged to ensure uniqueness."
-            )
+        # # Calculate the number of duplicates
+        # num_duplicates = len(bins) - len(set_of_bins)
+
+        # if num_duplicates > 0:
+        #     logging.warning(
+        #         f'{num_duplicates*2} bins with identical contig compositions detected in bin set "{name}". '
+        #         "These bins were merged to ensure uniqueness."
+        #     )
 
         # Store the unique set of bins
-        bin_set_name_to_bins[name] = set_of_bins
+        bin_set_name_to_bins_info[name] = bins
 
-    return bin_set_name_to_bins
+    return bin_set_name_to_bins_info
 
 
 def get_bins_from_contig2bin_table(contig2bin_table: Path, set_name: str) -> List[Bin]:
@@ -342,8 +342,8 @@ def get_bins_from_contig2bin_table(contig2bin_table: Path, set_name: str) -> Lis
 
     bins = []
     for bin_name, contigs in bin_name2contigs.items():
-        bin_obj = Bin(contigs, set_name, bin_name)
-        bins.append(bin_obj)
+        bin_dict = {"contigs": contigs, "set_name": set_name, "bin_name": bin_name}
+        bins.append(bin_dict)
     return bins
 
 
@@ -359,7 +359,7 @@ def from_bins_to_bin_graph(bins) -> nx.Graph:
 
     for bin1, bin2 in itertools.combinations(bins, 2):
         if bin1.overlaps_with(bin2):
-            G.add_edge(bin1, bin2)
+            G.add_edge(bin1.contigs_key, bin2.contigs_key)
     return G
 
 
@@ -458,29 +458,104 @@ def get_union_bins(cliques: List[List[Bin]]) -> Set[Bin]:
     return union_bins
 
 
-def select_best_bins(bins: Set[Bin]) -> List[Bin]:
+def build_contig_index(bins_dict: dict[bytes, Bin]) -> dict[int, set[bytes]]:
     """
-    Selects the best bins from a list of bins based on their scores, N50 values, and IDs.
-
-    :param bins: A list of Bin objects.
-
-    :return: A list of selected Bin objects.
+    Build an inverted index: contig_id -> set of contigs_key of bins containing it.
     """
+    contig_to_bins = defaultdict(set)
+    for key, bin_obj in bins_dict.items():
+        for contig in bin_obj.contigs:
+            contig_to_bins[contig].add(key)
+    return contig_to_bins
+
+
+def remove_bins_from_index(
+    bin_keys: set[bytes],
+    bins_dict: dict[bytes, Bin],
+    contig_to_bins: dict[int, set[bytes]],
+) -> None:
+    """
+    Remove a set of bins from the inverted index.
+
+    :param bin_keys: The contig_keys of bins to remove.
+    :param bins_dict: Mapping from contig_key -> Bin.
+    :param contig_to_bins: Inverted index (contig_id -> set of contig_keys).
+    """
+    for key in bin_keys:
+        ob = bins_dict.get(key)
+        if ob is not None:
+            for c in ob.contigs:
+                contig_to_bins[c].discard(key)
+
+
+def select_best_bins(
+    bins_dict: dict[bytes, Bin],
+    min_completeness: float,
+    max_contamination: float,
+) -> list[Bin]:
+    """
+    Select the best non-overlapping bins based on score, N50, and ID.
+    """
+    logging.info("Selecting best bins...")
+
+    logging.info(
+        f"Filtering bins: only bins with completeness >= {min_completeness} "
+        f"and contamination <= {max_contamination}"
+    )
+    good_enough_bins = {
+        k: b
+        for k, b in bins_dict.items()
+        if b.completeness >= min_completeness and b.contamination <= max_contamination
+    }
 
     logging.info("Sorting bins")
-    # Sort on score, N50, and ID. Smaller ID values are preferred to select original bins first.
-    sorted_bins = sorted(bins, key=lambda x: (x.score, x.N50, -x.id), reverse=True)
+    sorted_bin_keys = sorted(
+        good_enough_bins,
+        key=lambda k: (
+            -good_enough_bins[k].score,
+            -good_enough_bins[k].N50,
+            -good_enough_bins[k].is_original,
+            k,  # contigs_key itself is sortable (bytes)
+        ),
+    )
+
+    logging.info("Building contig index")
+    contig_to_bin_keys = build_contig_index(good_enough_bins)
 
     logging.info("Selecting bins")
     selected_bins = []
-    for b in sorted_bins:
-        if b in bins:
-            overlapping_bins = {b2 for b2 in bins if b.overlaps_with(b2)}
-            bins -= overlapping_bins
+    discarded_keys = set()
 
-            selected_bins.append(b)
+    for bin_key in sorted_bin_keys:
+        if bin_key in discarded_keys:
+            continue
+
+        bin_obj = good_enough_bins[bin_key]
+        selected_bins.append(bin_obj)
+
+        # Gather overlapping bins via inverted index
+        overlapping_bin_keys = set()
+        for contig in bin_obj.contigs:
+            overlapping_bin_keys |= contig_to_bin_keys[contig]
+
+        # Discard them
+        discarded_keys |= overlapping_bin_keys
+
+        # Remove discarded bins from index to shrink future lookups
+        remove_bins_from_index(
+            overlapping_bin_keys, good_enough_bins, contig_to_bin_keys
+        )
 
     logging.info(f"Selected {len(selected_bins)} bins")
+
+    # TODO use with a prefix from an optional argument of cli
+    prefix = "binette"
+    for i, selected_bin in enumerate(selected_bins, start=1):
+        if not selected_bin.origin:
+            selected_bin.origin = {"binette"}
+        if selected_bin.name is not None:
+            selected_bin.original_name = selected_bin.name
+        selected_bin.name = f"{prefix}_{i}"
     return selected_bins
 
 
@@ -534,7 +609,7 @@ def dereplicate_bin_sets(bin_sets: Iterable[Set["Bin"]]) -> Set["Bin"]:
     return dereplicated_bins
 
 
-def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> Set[str]:
+def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> List[str]:
     """
     Processes bin sets to check for duplicated contigs and logs detailed information about each bin set.
 
@@ -545,8 +620,10 @@ def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> Set[st
     # To track all unique contigs across bin sets
     all_contigs_in_bins = set()
 
-    for bin_set_name, bins in bin_set_name_to_bins.items():
-        list_contigs_in_bin_sets = get_contigs_in_bins(bins)
+    for bin_set_name, bins_info in bin_set_name_to_bins.items():
+        list_contigs_in_bin_sets = [
+            contig for bin_info in bins_info for contig in bin_info["contigs"]
+        ]
 
         contig_counts = Counter(list_contigs_in_bin_sets)
         duplicated_contigs = {
@@ -571,10 +648,10 @@ def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> Set[st
 
         # Log summary for the current bin set
         logging.debug(
-            f"Bin set '{bin_set_name}': {len(bins)} bins, {len(unique_contigs_in_bin_set)} unique contigs."
+            f"Bin set '{bin_set_name}': {len(bins_info)} bins, {len(unique_contigs_in_bin_set)} unique contigs."
         )
 
-    return all_contigs_in_bins
+    return list(all_contigs_in_bins)
 
 
 def get_contigs_in_bins(bins: Iterable[Bin]) -> List[str]:
@@ -588,19 +665,7 @@ def get_contigs_in_bins(bins: Iterable[Bin]) -> List[str]:
     return [contig for b in bins for contig in b.contigs]
 
 
-def rename_bin_contigs(bins: Iterable[Bin], contig_to_index: dict):
-    """
-    Renames the contigs in the bins based on the provided mapping.
-
-    :param bins: A list of Bin objects.
-    :param contig_to_index: A dictionary mapping old contig names to new index names.
-    """
-    for b in bins:
-        b.contigs = BitMap(contig_to_index[contig] for contig in b.contigs)
-        b.hash = hash(str(sorted(b.contigs)))
-
-
-def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
+def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
     """
     Creates intermediate bins from a dictionary of bin sets.
 
@@ -615,69 +680,67 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
     max_len = 6_000_000
 
     logging.info("Making bin graph...")
-    connected_bins_graph = from_bins_to_bin_graph(original_bins)
+    connected_bins_graph = from_bins_to_bin_graph(contig_key_to_initial_bin.values())
 
     cliques_of_bins = sorted(
         [sorted(clique) for clique in nx.clique.find_cliques(connected_bins_graph)]
     )
-
-    bin_id_to_bitmap_bin = {
-        bin_obj.id: BitMap(bin_obj.contigs) for bin_obj in original_bins
-    }
-    new_bitmap_bins = []
-
-    bins_serializers_to_id = {
-        bitmap_bin.serialize(): bin_id
-        for bin_id, bitmap_bin in bin_id_to_bitmap_bin.items()
-    }
 
     logging.info("Creating union, difference, and intersection bins...")
 
     intersec_count = 0
     union_count = 0
     diff_count = 0
-
+    contig_key_to_new_contigs_set = {}
     for clique in tqdm(
         cliques_of_bins, total=len(cliques_of_bins), unit="clique of bins"
     ):
         bins_combinations = get_all_possible_combinations(clique)
 
-        for bins in bins_combinations:
-            bitmap_bins = [bin_id_to_bitmap_bin[bin_obj.id] for bin_obj in bins]
+        for bin_contig_keys in bins_combinations:
+
+            bins = [contig_key_to_initial_bin[ck] for ck in bin_contig_keys]
 
             if all((b.completeness for b in bins)) > min_comp:
 
-                intersec_bin = bitmap_bins[0].intersection(*bitmap_bins[1:])
+                intersec_contigs = bins[0].contig_intersection(*bins[1:])
 
-                if intersec_bin:  # and intersec_bin not in clique:
-                    intersec_bin_serialize = intersec_bin.serialize()
-                    if intersec_bin_serialize not in bins_serializers_to_id:
-                        bins_serializers_to_id[intersec_bin_serialize] = None
-                        new_bitmap_bins.append(intersec_bin)
+                if intersec_contigs:
+                    contig_key = intersec_contigs.serialize()
+                    if (
+                        contig_key not in contig_key_to_initial_bin
+                        and contig_key not in contig_key_to_new_contigs_set
+                    ):
+                        contig_key_to_new_contigs_set[contig_key] = intersec_contigs
                         intersec_count += 1
 
             for bin_a in bins:
-                bitmap_bin_a = bin_id_to_bitmap_bin[bin_a.id]
                 if bin_a.completeness >= min_comp:
-                    bin_diff = bitmap_bin_a.difference(
-                        *(b for b in bitmap_bins if b != bitmap_bin_a)
+
+                    diff_contigs = bin_a.contig_difference(
+                        *(b for b in bins if b != bin_a)
                     )
 
-                    if bin_diff:
-                        bin_diff_serialize = bin_diff.serialize()
-                        if bin_diff_serialize not in bins_serializers_to_id:
-                            bins_serializers_to_id[bin_diff_serialize] = None
-                            new_bitmap_bins.append(bin_diff)
+                    if diff_contigs:
+                        contig_key = diff_contigs.serialize()
+
+                        if (
+                            contig_key not in contig_key_to_initial_bin
+                            and contig_key not in contig_key_to_new_contigs_set
+                        ):
+                            contig_key_to_new_contigs_set[contig_key] = diff_contigs
                             diff_count += 1
 
             if all((b.contamination for b in bins)) <= max_conta:
 
-                bin_union = bitmap_bins[0].union(*bitmap_bins[1:])
-                if bin_union:
-                    bin_union_serialize = bin_union.serialize()
-                    if bin_union_serialize not in bins_serializers_to_id:
-                        bins_serializers_to_id[bin_union_serialize] = None
-                        new_bitmap_bins.append(bin_union)
+                union_contigs = bins[0].contig_union(*bins[1:])
+                if union_contigs:
+                    contig_key = union_contigs.serialize()
+                    if (
+                        contig_key not in contig_key_to_initial_bin
+                        and contig_key not in contig_key_to_new_contigs_set
+                    ):
+                        contig_key_to_new_contigs_set[contig_key] = union_contigs
                         union_count += 1
 
     logging.info(f"{intersec_count} bins created on intersections.")
@@ -686,13 +749,13 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
 
     logging.info(f"{union_count} bins created on unions.")
 
+    contig_key_to_new_bin = {
+        contig_key: Bin(contigs, is_original=False)
+        for contig_key, contigs in contig_key_to_new_contigs_set.items()
+    }
+
     logging.info(
-        f"{len(new_bitmap_bins)} new bins created from {len(original_bins)} input bins."
+        f"{len(contig_key_to_new_bin)} new bins created from {len(contig_key_to_initial_bin)} input bins."
     )
 
-    new_bins = [
-        Bin(contigs, origin="intermediate", name=i)
-        for i, contigs in enumerate(new_bitmap_bins)
-    ]
-
-    return set(new_bins)
+    return contig_key_to_new_bin

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -259,7 +259,7 @@ def parse_bin_directories(
     :param bin_name_to_bin_dir: A dictionary mapping bin names to their respective bin directories.
     :fasta_extensions: Possible fasta extensions to look for in the bin directory.
 
-    :return: A dictionary mapping bin names to a list of Bin objects created from the bin directories.
+    :return: A dictionary mapping bin names to a list of dict created from the bin directories.
     """
     bin_set_name_to_bins_info = {}
 
@@ -321,14 +321,16 @@ def parse_contig2bin_tables(
     return bin_set_name_to_bins_info
 
 
-def get_bins_from_contig2bin_table(contig2bin_table: Path, set_name: str) -> List[Bin]:
+def get_bins_from_contig2bin_table(
+    contig2bin_table: Path, set_name: str
+) -> List[Dict[str, Any]]:
     """
     Retrieves a list of Bin objects from a contig-to-bin table.
 
     :param contig2bin_table: The path to the contig-to-bin table.
     :param set_name: The name of the set the bins belong to.
 
-    :return: A list of Bin objects created from the contig-to-bin table.
+    :return: A list of Bin info in dict created from the contig-to-bin table.
     """
     bin_name2contigs = defaultdict(set)
     with open(contig2bin_table) as fl:
@@ -347,7 +349,7 @@ def get_bins_from_contig2bin_table(contig2bin_table: Path, set_name: str) -> Lis
     return bins
 
 
-def from_bins_to_bin_graph(bins) -> nx.Graph:
+def from_bins_to_bin_graph(bins: Iterable[Bin]) -> nx.Graph:
     """
     Creates a bin graph made of overlapping gram a set of bins.
 
@@ -376,91 +378,11 @@ def get_all_possible_combinations(clique: List) -> Iterable[Tuple]:
     )
 
 
-def get_intersection_bins(cliques: List[List[Bin]]) -> Set[Bin]:
-    """
-    Retrieves the intersection bins from a given list of cliques.
-
-    :param cliques: A list of cliques.
-
-    :return: A set of Bin objects representing the intersection bins.
-    """
-    intersect_bins = set()
-
-    with tqdm(unit="clique of bins", total=len(cliques)) as pbar:
-
-        for clique in cliques:
-            pbar.update()
-            bins_combinations = get_all_possible_combinations(clique)
-            for bins in bins_combinations:
-                if max((b.completeness for b in bins)) < 40:
-                    continue
-
-                intersec_bin = bins[0].intersection(*bins[1:])
-
-                if intersec_bin.contigs:  # and intersec_bin not in clique:
-
-                    intersect_bins.add(intersec_bin)
-
-    return intersect_bins
-
-
-def get_difference_bins(cliques: List[List[Bin]]) -> Set[Bin]:
-    """
-    Retrieves the difference bins from a given graph.
-
-    :param cliques: A list of cliques.
-
-    :return: A set of Bin objects representing the difference bins.
-    """
-    difference_bins = set()
-    with tqdm(unit="clique of bins", total=len(cliques)) as pbar:
-
-        for clique in cliques:
-            pbar.update()
-            bins_combinations = get_all_possible_combinations(clique)
-            for bins in bins_combinations:
-
-                for bin_a in bins:
-                    if bin_a.completeness < 40:
-                        continue
-                    bin_diff = bin_a.difference(*(b for b in bins if b != bin_a))
-
-                    if bin_diff.contigs:  # and bin_diff not in clique:
-                        difference_bins.add(bin_diff)
-
-    return difference_bins
-
-
-def get_union_bins(cliques: List[List[Bin]]) -> Set[Bin]:
-    """
-    Retrieves the union bins from a given graph.
-
-    :param cliques: A list of cliques.
-
-    :return: A set of Bin objects representing the union bins.
-    """
-    union_bins = set()
-    with tqdm(unit="clique of bins", total=len(cliques)) as pbar:
-
-        for clique in cliques:
-            pbar.update()
-            bins_combinations = get_all_possible_combinations(clique)
-            for bins in bins_combinations:
-                if max((b.contamination for b in bins)) > 20:
-                    continue
-
-                bins = sorted(set(bins))
-                bin_a = bins.pop()
-                bin_union = bin_a.union(*bins)
-                if bin_union.contigs:  # and bin_union not in clique:
-                    union_bins.add(bin_union)
-
-    return union_bins
-
-
 def build_contig_index(bins_dict: dict[bytes, Bin]) -> dict[int, set[bytes]]:
     """
     Build an inverted index: contig_id -> set of contigs_key of bins containing it.
+    :param bins_dict: Mapping from contigs_key -> Bin.
+    :return: Inverted index (contig_id -> set of contigs_key).
     """
     contig_to_bins = defaultdict(set)
     for key, bin_obj in bins_dict.items():
@@ -559,56 +481,6 @@ def select_best_bins(
     return selected_bins
 
 
-def group_identical_bins(bins: Iterable[Bin]) -> List[List[Bin]]:
-    """
-    Group identical bins together
-
-    :param bins: list of bins
-
-    return List of list of identical bins
-    """
-    binhash_to_bins = defaultdict(list)
-
-    # Collect bins by their hash values
-    for bin_obj in bins:
-        binhash_to_bins[bin_obj.hash].append(bin_obj)
-
-    return list(binhash_to_bins.values())
-
-
-def dereplicate_bin_sets(bin_sets: Iterable[Set["Bin"]]) -> Set["Bin"]:
-    """
-    Consolidate bins from multiple bin sets into a single set of non-redundant bins.
-
-    Bins with the same hash are considered duplicates. For each group of duplicates,
-    the origins are merged, and only one representative bin is kept.
-
-    :param bin_sets: An iterable of sets, where each set contains `Bin` objects. These sets are merged
-                     into a single set of unique bins by consolidating bins with the same hash.
-
-    :return: A set of `Bin` objects with duplicates removed. Each `Bin` in the resulting set has
-             merged origins from the bins it was consolidated with.
-    """
-    all_bins = (bin_obj for bins in bin_sets for bin_obj in bins)
-    list_of_identical_bins = group_identical_bins(all_bins)
-
-    dereplicated_bins = set()
-
-    # Merge bins with the same hash
-    for identical_bins in list_of_identical_bins:
-        identical_bins.sort()
-        # Select the first bin as the representative
-        selected_bin = identical_bins[0]
-        for bin_obj in identical_bins[1:]:
-            # Merge origins of all bins with the same hash
-            selected_bin.origin |= bin_obj.origin
-
-        # Add the representative bin to the result set
-        dereplicated_bins.add(selected_bin)
-
-    return dereplicated_bins
-
-
 def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> List[str]:
     """
     Processes bin sets to check for duplicated contigs and logs detailed information about each bin set.
@@ -652,17 +524,6 @@ def get_contigs_in_bin_sets(bin_set_name_to_bins: Dict[str, Set[Bin]]) -> List[s
         )
 
     return list(all_contigs_in_bins)
-
-
-def get_contigs_in_bins(bins: Iterable[Bin]) -> List[str]:
-    """
-    Retrieves all contigs present in the given list of bins.
-
-    :param bins: A list of Bin objects.
-
-    :return: A list of contigs present in the bins.
-    """
-    return [contig for b in bins for contig in b.contigs]
 
 
 def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
@@ -749,7 +610,7 @@ def create_intermediate_bins(contig_key_to_initial_bin: Dict[bytes, Bin]):
 
     logging.info(f"{union_count} bins created on unions.")
 
-    contig_key_to_new_bin = {
+    contig_key_to_new_bin: Dict[bytes, Bin] = {
         contig_key: Bin(contigs, is_original=False)
         for contig_key, contigs in contig_key_to_new_contigs_set.items()
     }

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -31,7 +31,12 @@ class Bin:
         self.origin = {origin}
         self.name = name
         self.id = Bin.counter
-        self.contigs = set(contigs)
+        # check contigs type
+        if isinstance(contigs, BitMap):
+            self.contigs = contigs
+        else:
+            self.contigs = set(contigs)
+
         self.hash = hash(str(sorted(self.contigs)))
 
         self.length = None
@@ -591,7 +596,7 @@ def rename_bin_contigs(bins: Iterable[Bin], contig_to_index: dict):
     :param contig_to_index: A dictionary mapping old contig names to new index names.
     """
     for b in bins:
-        b.contigs = {contig_to_index[contig] for contig in b.contigs}
+        b.contigs = BitMap(contig_to_index[contig] for contig in b.contigs)
         b.hash = hash(str(sorted(b.contigs)))
 
 
@@ -640,7 +645,7 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
         for bins in bins_combinations:
             bitmap_bins = [bin_id_to_bitmap_bin[bin_obj.id] for bin_obj in bins]
 
-            if max((b.completeness for b in bins)) > min_comp:
+            if all((b.completeness for b in bins)) > min_comp:
 
                 intersec_bin = bitmap_bins[0].intersection(*bitmap_bins[1:])
 
@@ -665,7 +670,7 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
                             new_bitmap_bins.append(bin_diff)
                             diff_count += 1
 
-            if max((b.contamination for b in bins)) <= max_conta:
+            if all((b.contamination for b in bins)) <= max_conta:
 
                 bin_union = bitmap_bins[0].union(*bitmap_bins[1:])
                 if bin_union:
@@ -684,9 +689,10 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
     logging.info(
         f"{len(new_bitmap_bins)} new bins created from {len(original_bins)} input bins."
     )
-    # b_list = sorted([sorted(list(new_bin)) for new_bin in new_bitmap_bins])
 
-    # for i, contigs in enumerate(b_list):
-    #     print(f"{i + 1} - {contigs}")
+    new_bins = [
+        Bin(contigs, origin="intermediate", name=i)
+        for i, contigs in enumerate(new_bitmap_bins)
+    ]
 
-    return new_bitmap_bins
+    return set(new_bins)

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -14,6 +14,7 @@ from pyroaring import BitMap
 from functools import cached_property
 import numpy as np
 
+
 class Bin:
 
     def __init__(

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -10,6 +10,7 @@ from typing import List, Dict, Iterable, Tuple, Set
 from tqdm import tqdm
 
 from collections import Counter
+from pyroaring import BitMap
 
 
 class Bin:
@@ -88,19 +89,6 @@ class Bin:
         """
         return self.contigs & other.contigs
 
-    # def __and__(self, other: 'Bin') -> 'Bin':
-    #     """
-    #     Perform a logical AND operation between this bin and another bin.
-
-    #     :param other: The other Bin object.
-    #     :return: A new Bin object representing the intersection of the bins.
-    #     """
-    #     contigs = self.contigs & other.contigs
-    #     name = f"{self.name} & {other.name}"
-    #     origin = "intersection"
-
-    #     return Bin(contigs, origin, name)
-
     def add_length(self, length: int) -> None:
         """
         Add the length attribute to the Bin object if the provided length is a positive integer.
@@ -139,48 +127,48 @@ class Bin:
         self.contamination = contamination
         self.score = completeness - contamination_weight * contamination
 
-    def intersection(self, *others: "Bin") -> "Bin":
-        """
-        Compute the intersection of the bin with other bins.
+    # def intersection(self, *others: "Bin") -> "Bin":
+    #     """
+    #     Compute the intersection of the bin with other bins.
 
-        :param others: Other bins to compute the intersection with.
-        :return: A new Bin representing the intersection of the bins.
-        """
-        other_contigs = (o.contigs for o in others)
-        contigs = self.contigs.intersection(*other_contigs)
-        name = f"{self.id} & {' & '.join([str(other.id) for other in sorted(others)])}"
-        origin = "intersec"
+    #     :param others: Other bins to compute the intersection with.
+    #     :return: A new Bin representing the intersection of the bins.
+    #     """
+    #     other_contigs = (o.contigs for o in others)
+    #     contigs = self.contigs.intersection(*other_contigs)
+    #     name = f"{self.id} & {' & '.join([str(other.id) for other in sorted(others)])}"
+    #     origin = "intersec"
 
-        return Bin(contigs, origin, name)
+    #     return Bin(contigs, origin, name)
 
-    def difference(self, *others: "Bin") -> "Bin":
-        """
-        Compute the difference between the bin and other bins.
+    # def difference(self, *others: "Bin") -> "Bin":
+    #     """
+    #     Compute the difference between the bin and other bins.
 
-        :param others: Other bins to compute the difference with.
-        :return: A new Bin representing the difference between the bins.
-        """
-        other_contigs = (o.contigs for o in others)
-        contigs = self.contigs.difference(*other_contigs)
-        name = f"{self.id} - {' - '.join([str(other.id) for other in sorted(others)])}"
-        origin = "diff"
+    #     :param others: Other bins to compute the difference with.
+    #     :return: A new Bin representing the difference between the bins.
+    #     """
+    #     other_contigs = (o.contigs for o in others)
+    #     contigs = self.contigs.difference(*other_contigs)
+    #     name = f"{self.id} - {' - '.join([str(other.id) for other in sorted(others)])}"
+    #     origin = "diff"
 
-        return Bin(contigs, origin, name)
+    #     return Bin(contigs, origin, name)
 
-    def union(self, *others: "Bin") -> "Bin":
-        """
-        Compute the union of the bin with other bins.
+    # def union(self, *others: "Bin") -> "Bin":
+    #     """
+    #     Compute the union of the bin with other bins.
 
-        :param others: Other bins to compute the union with.
-        :return: A new Bin representing the union of the bins.
-        """
-        other_contigs = (o.contigs for o in others)
-        contigs = self.contigs.union(*other_contigs)
-        name = f"{self.id} | {' | '.join([str(other.id) for other in sorted(others)])}"
+    #     :param others: Other bins to compute the union with.
+    #     :return: A new Bin representing the union of the bins.
+    #     """
+    #     other_contigs = (o.contigs for o in others)
+    #     contigs = self.contigs.union(*other_contigs)
+    #     name = f"{self.id} | {' | '.join([str(other.id) for other in sorted(others)])}"
 
-        origin = "union"
+    #     origin = "union"
 
-        return Bin(contigs, origin, name)
+    #     return Bin(contigs, origin, name)
 
     def is_complete_enough(self, min_completeness: float) -> bool:
         """
@@ -615,6 +603,11 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
 
     :return: A set of intermediate bins created from intersections, differences, and unions.
     """
+    min_comp = 40
+    max_conta = 20
+
+    min_len = 500_000
+    max_len = 6_000_000
 
     logging.info("Making bin graph...")
     connected_bins_graph = from_bins_to_bin_graph(original_bins)
@@ -623,35 +616,77 @@ def create_intermediate_bins(original_bins: Set[Bin]) -> Set[Bin]:
         [sorted(clique) for clique in nx.clique.find_cliques(connected_bins_graph)]
     )
 
-    logging.info("Creating intersection bins...")
-    intersection_bins = get_intersection_bins(cliques_of_bins)
+    bin_id_to_bitmap_bin = {
+        bin_obj.id: BitMap(bin_obj.contigs) for bin_obj in original_bins
+    }
+    new_bitmap_bins = []
 
-    logging.info(f"{len(intersection_bins)} bins created on intersections.")
+    bins_serializers_to_id = {
+        bitmap_bin.serialize(): bin_id
+        for bin_id, bitmap_bin in bin_id_to_bitmap_bin.items()
+    }
 
-    logging.info("Creating difference bins...")
-    difference_bins = get_difference_bins(cliques_of_bins)
+    logging.info("Creating union, difference, and intersection bins...")
 
-    logging.info(f"{len(difference_bins)} bins created based on symmetric difference.")
+    intersec_count = 0
+    union_count = 0
+    diff_count = 0
 
-    logging.info("Creating union bins...")
-    union_bins = get_union_bins(cliques_of_bins)
+    for clique in tqdm(
+        cliques_of_bins, total=len(cliques_of_bins), unit="clique of bins"
+    ):
+        bins_combinations = get_all_possible_combinations(clique)
 
-    logging.info(f"{len(union_bins)} bins created on unions.")
+        for bins in bins_combinations:
+            bitmap_bins = [bin_id_to_bitmap_bin[bin_obj.id] for bin_obj in bins]
 
-    new_bins = difference_bins | intersection_bins | union_bins
+            if max((b.completeness for b in bins)) > min_comp:
 
-    new_bins = dereplicate_bin_sets((difference_bins, intersection_bins, union_bins))
+                intersec_bin = bitmap_bins[0].intersection(*bitmap_bins[1:])
 
-    # dereplicate from the original bins
-    original_hashes = [b.hash for b in original_bins]
-    new_bins_not_in_original = set()
+                if intersec_bin:  # and intersec_bin not in clique:
+                    intersec_bin_serialize = intersec_bin.serialize()
+                    if intersec_bin_serialize not in bins_serializers_to_id:
+                        bins_serializers_to_id[intersec_bin_serialize] = None
+                        new_bitmap_bins.append(intersec_bin)
+                        intersec_count += 1
 
-    for b in new_bins:
-        if b.hash not in original_hashes:
-            new_bins_not_in_original.add(b)
+            for bin_a in bins:
+                bitmap_bin_a = bin_id_to_bitmap_bin[bin_a.id]
+                if bin_a.completeness >= min_comp:
+                    bin_diff = bitmap_bin_a.difference(
+                        *(b for b in bitmap_bins if b != bitmap_bin_a)
+                    )
+
+                    if bin_diff:
+                        bin_diff_serialize = bin_diff.serialize()
+                        if bin_diff_serialize not in bins_serializers_to_id:
+                            bins_serializers_to_id[bin_diff_serialize] = None
+                            new_bitmap_bins.append(bin_diff)
+                            diff_count += 1
+
+            if max((b.contamination for b in bins)) <= max_conta:
+
+                bin_union = bitmap_bins[0].union(*bitmap_bins[1:])
+                if bin_union:
+                    bin_union_serialize = bin_union.serialize()
+                    if bin_union_serialize not in bins_serializers_to_id:
+                        bins_serializers_to_id[bin_union_serialize] = None
+                        new_bitmap_bins.append(bin_union)
+                        union_count += 1
+
+    logging.info(f"{intersec_count} bins created on intersections.")
+
+    logging.info(f"{diff_count} bins created based on symmetric difference.")
+
+    logging.info(f"{union_count} bins created on unions.")
 
     logging.info(
-        f"{len(new_bins)} new bins created from {len(original_bins)} input bins."
+        f"{len(new_bitmap_bins)} new bins created from {len(original_bins)} input bins."
     )
+    # b_list = sorted([sorted(list(new_bin)) for new_bin in new_bitmap_bins])
 
-    return new_bins_not_in_original
+    # for i, contigs in enumerate(b_list):
+    #     print(f"{i + 1} - {contigs}")
+
+    return new_bitmap_bins

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -3,11 +3,11 @@ import logging
 import os
 from collections import Counter
 from itertools import islice
-from typing import Dict, Iterable, Optional, Tuple, Iterator, Set
+from typing import Dict, Iterable, Optional, Tuple, Iterator, List
 
 import numpy as np
 import pandas as pd
-from binette.bin_manager import Bin
+from binette.bin_manager import Bin, BitmapBin
 from tqdm import tqdm
 
 # Suppress unnecessary TensorFlow warnings
@@ -19,7 +19,7 @@ from checkm2 import keggData, modelPostprocessing, modelProcessing  # noqa: E402
 
 
 def get_bins_metadata_df(
-    bins: Iterable[Bin],
+    bins: List[BitmapBin],
     contig_to_cds_count: Dict[str, int],
     contig_to_aa_counter: Dict[str, Counter],
     contig_to_aa_length: Dict[str, int],
@@ -40,7 +40,7 @@ def get_bins_metadata_df(
     bin_metadata_list = []
     for bin_obj in bins:
         bin_metadata = {
-            "Name": bin_obj.id,
+            "Name": bin_obj.contigs_key,
             "CDS": sum(
                 (
                     contig_to_cds_count[c]
@@ -76,7 +76,7 @@ def get_bins_metadata_df(
 
 
 def get_diamond_feature_per_bin_df(
-    bins: Iterable[Bin], contig_to_kegg_counter: Dict[str, Counter]
+    bins: List[BitmapBin], contig_to_kegg_counter: Dict[str, Counter]
 ) -> Tuple[pd.DataFrame, int]:
     """
     Generate a DataFrame containing Diamond feature counts per bin and completeness information for pathways, categories, and modules.
@@ -101,7 +101,7 @@ def get_diamond_feature_per_bin_df(
                 # No KO annotation found in this contig
                 continue
 
-        bin_to_ko_counter[bin_obj.id] = bin_ko_counter
+        bin_to_ko_counter[bin_obj.contigs_key] = bin_ko_counter
 
     ko_count_per_bin_df = (
         pd.DataFrame(bin_to_ko_counter, index=defaultKOs).transpose().fillna(0)
@@ -128,43 +128,49 @@ def get_diamond_feature_per_bin_df(
     return diamond_complete_results, len(defaultKOs)
 
 
-def compute_N50(list_of_lengths) -> int:
+def prepare_contig_sizes(contig_to_size: Dict[int, int]):
     """
-    Calculate N50 for a sequence of numbers.
-
-    :param list_of_lengths: List of numbers.
-    :param list_of_lengths: list
-    :return: N50 value.
+    Prepare a numpy array of contig sizes for fast access.
     """
-    list_of_lengths = sorted(list_of_lengths)
-    sum_len = sum(list_of_lengths)
 
-    cum_length = 0
-    length = 0
-    for length in list_of_lengths:
-        if cum_length + length >= sum_len / 2:
-            return length
-        cum_length += length
-    return length
+    max_id = max(contig_to_size)
+    contig_sizes = np.zeros(max_id + 1, dtype=np.int64)
+    for cid, size in contig_to_size.items():
+        contig_sizes[cid] = size
+    return contig_sizes
 
 
-def add_bin_size_and_N50(bins: Iterable[Bin], contig_to_size: Dict[str, int]):
+def compute_N50(lengths: np.ndarray) -> int:
+    arr = np.sort(lengths)
+    half = arr.sum() / 2
+    csum = np.cumsum(arr)
+    return arr[np.searchsorted(csum, half)]
+
+
+def add_bin_size_and_N50(bins: Iterable[Bin], contig_to_size: Dict[int, int]):
     """
     Add bin size and N50 to a list of bin objects.
 
     :param bins: List of bin objects.
     :param contig_to_size: Dictionary mapping contig names to their sizes.
     """
+    # TODO use numpy array everywhere instead of contig_to_size
+    contig_sizes = prepare_contig_sizes(contig_to_size)
+
     for bin_obj in bins:
-        lengths = [contig_to_size[c] for c in bin_obj.contigs]
+        lengths = contig_sizes[list(bin_obj.contigs)]  # fast bulk lookup
+        total_len = lengths.sum()
         n50 = compute_N50(lengths)
 
-        bin_obj.add_length(sum(lengths))
-        bin_obj.add_N50(n50)
+        bin_obj.add_length(int(total_len))
+        bin_obj.add_N50(int(n50))
 
 
 def add_bin_metrics(
-    bins: Set[Bin], contig_info: Dict, contamination_weight: float, threads: int = 1
+    bins: List[Bin],
+    contig_info: Dict,
+    contamination_weight: float,
+    threads: int = 1,
 ):
     """
     Add metrics to a Set of bins.
@@ -182,13 +188,11 @@ def add_bin_metrics(
     contig_to_cds_count = contig_info["contig_to_cds_count"]
     contig_to_aa_counter = contig_info["contig_to_aa_counter"]
     contig_to_aa_length = contig_info["contig_to_aa_length"]
-    contig_to_length = contig_info["contig_to_length"]
 
     logging.info("Getting bin length and N50")
 
-    add_bin_size_and_N50(bins, contig_to_length)
-
     logging.info(f"Assessing bin quality for {len(bins)} bins.")
+
     assess_bins_quality_by_chunk(
         bins,
         contig_to_kegg_counter,
@@ -243,7 +247,7 @@ def assess_bins_quality_by_chunk(
     """
     with tqdm(total=len(bins), unit="bin", disable=disable_bar) as pbar:
         for i, chunk_bins_iter in enumerate(chunks(bins, chunk_size)):
-            chunk_bins = set(chunk_bins_iter)
+            chunk_bins = list(chunk_bins_iter)
             logging.debug(f"chunk {i}: assessing quality of {len(chunk_bins)} bins")
             bins_scored = assess_bins_quality(
                 bins=chunk_bins,
@@ -335,8 +339,9 @@ def assess_bins_quality(
     final_results["Contamination"] = np.round(final_cont, 2)
 
     for bin_obj in bins:
-        completeness = final_results.at[bin_obj.id, "Completeness"]
-        contamination = final_results.at[bin_obj.id, "Contamination"]
+        completeness = final_results.at[bin_obj.contigs_key, "Completeness"]
+        contamination = final_results.at[bin_obj.contigs_key, "Contamination"]
 
         bin_obj.add_quality(completeness, contamination, contamination_weight)
+
     return bins

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from binette.bin_manager import Bin
 from tqdm import tqdm
+from collections import defaultdict
 
 # Suppress unnecessary TensorFlow warnings
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -25,53 +26,61 @@ def get_bins_metadata_df(
     contig_to_aa_length: Dict[str, int],
 ) -> pd.DataFrame:
     """
-    Generate a DataFrame containing metadata for a list of bins.
-
-    :param bins: A list of bin objects.
-    :param contig_to_cds_count: A dictionary mapping contig names to CDS counts.
-    :param contig_to_aa_counter: A dictionary mapping contig names to amino acid composition (Counter object).
-    :param contig_to_aa_length: A dictionary mapping contig names to total amino acid length.
-    :return: A DataFrame containing bin metadata.
+    Optimized: Generate a DataFrame containing metadata for a list of bins.
+    Handles contigs that appear in multiple bins.
     """
-
     metadata_order = keggData.KeggCalculator().return_proper_order("Metadata")
+    bin_keys = [b.contigs_key for b in bins]
 
-    # Get bin metadata
-    bin_metadata_list = []
-    for bin_obj in bins:
-        bin_metadata = {
-            "Name": bin_obj.contigs_key,
-            "CDS": sum(
-                (
-                    contig_to_cds_count[c]
-                    for c in bin_obj.contigs
-                    if c in contig_to_cds_count
-                )
-            ),
-            "AALength": sum(
-                (
-                    contig_to_aa_length[c]
-                    for c in bin_obj.contigs
-                    if c in contig_to_aa_length
-                )
-            ),
+    # --- Pre-aggregate CDS and AA length ---
+    cds_per_bin = defaultdict(int)
+    aa_len_per_bin = defaultdict(int)
+    aa_counter_per_bin = defaultdict(Counter)
+
+    # map contigs → all bins they belong to
+    contig_to_bins = defaultdict(list)
+    for b in bins:
+        for c in b.contigs:
+            contig_to_bins[c].append(b.contigs_key)
+
+    # distribute CDS counts
+    for contig, cds in contig_to_cds_count.items():
+        for bin_key in contig_to_bins.get(contig, []):
+            cds_per_bin[bin_key] += cds
+
+    # distribute AA lengths
+    for contig, length in contig_to_aa_length.items():
+        for bin_key in contig_to_bins.get(contig, []):
+            aa_len_per_bin[bin_key] += length
+
+    # distribute AA counters
+    for contig, counter in contig_to_aa_counter.items():
+        for bin_key in contig_to_bins.get(contig, []):
+            aa_counter_per_bin[bin_key].update(counter)
+
+    # --- Build rows ---
+    rows = []
+    for key in bin_keys:
+        row = {
+            "Name": key,
+            "CDS": cds_per_bin.get(key, 0),
+            "AALength": aa_len_per_bin.get(key, 0),
         }
+        row.update(aa_counter_per_bin.get(key, {}))
+        rows.append(row)
 
-        bin_aa_counter = Counter()
-        for contig in bin_obj.contigs:
-            if contig in contig_to_aa_counter:
-                bin_aa_counter += contig_to_aa_counter[contig]
+    # --- Construct DataFrame directly ---
+    metadata_df = pd.DataFrame(rows).fillna(0)
 
-        bin_metadata.update(dict(bin_aa_counter))
-        bin_metadata_list.append(bin_metadata)
+    # Ensure column order
+    all_cols = ["Name"] + metadata_order
+    for col in metadata_order:
+        if col not in metadata_df.columns:
+            metadata_df[col] = 0
 
-    metadata_df = pd.DataFrame(bin_metadata_list, columns=["Name"] + metadata_order)
-
-    metadata_df = metadata_df.fillna(0)
-
-    metadata_df = metadata_df.astype({col: int for col in metadata_order})
-
+    metadata_df = metadata_df[all_cols].astype({col: int for col in metadata_order})
     metadata_df = metadata_df.set_index("Name", drop=False)
+
     return metadata_df
 
 
@@ -79,48 +88,54 @@ def get_diamond_feature_per_bin_df(
     bins: List[Bin], contig_to_kegg_counter: Dict[str, Counter]
 ) -> Tuple[pd.DataFrame, int]:
     """
-    Generate a DataFrame containing Diamond feature counts per bin and completeness information for pathways, categories, and modules.
-
-    :param bins: A list of bin objects.
-    :param contig_to_kegg_counter: A dictionary mapping contig names to KEGG annotation counters.
-    :type bins: List
-    :type contig_to_kegg_counter: Dict[str, Counter]
-    :return: A tuple containing the DataFrame and the number of default KEGG orthologs (KOs).
-    :rtype: Tuple[pd.DataFrame, int]
+    Optimized: Generate a DataFrame containing Diamond feature counts per bin,
+    including KEGG KO counts and completeness information for pathways, categories, and modules.
+    Handles contigs that may belong to multiple bins.
     """
     KeggCalc = keggData.KeggCalculator()
     defaultKOs = KeggCalc.return_default_values_from_category("KO_Genes")
+    bin_keys = [b.contigs_key for b in bins]
 
+    # --- Build contig → bins mapping ---
+    contig_to_bins = defaultdict(list)
+    for b in bins:
+        for c in b.contigs:
+            contig_to_bins[c].append(b.contigs_key)
+
+    # --- Aggregate KO counters per bin ---
     bin_to_ko_counter = {}
     for bin_obj in bins:
         bin_ko_counter = Counter()
         for contig in bin_obj.contigs:
-            try:
-                bin_ko_counter += contig_to_kegg_counter[contig]
-            except KeyError:
-                # No KO annotation found in this contig
-                continue
-
+            ko_counter = contig_to_kegg_counter.get(contig)
+            if ko_counter:
+                bin_ko_counter.update(ko_counter)
         bin_to_ko_counter[bin_obj.contigs_key] = bin_ko_counter
 
+    # --- Build KO count DataFrame directly ---
     ko_count_per_bin_df = (
-        pd.DataFrame(bin_to_ko_counter, index=defaultKOs).transpose().fillna(0)
+        pd.DataFrame.from_dict(bin_to_ko_counter, orient="index")
+        .reindex(bin_keys)  # keep bin order
+        .fillna(0)
+        .astype(int)
     )
-    ko_count_per_bin_df = ko_count_per_bin_df.astype(int)
+
+    # Ensure all defaultKOs exist
+    ko_count_per_bin_df = ko_count_per_bin_df.reindex(
+        columns=list(defaultKOs), fill_value=0
+    )
+
+    # ko_count_per_bin_df.index.name = "Name"
     ko_count_per_bin_df["Name"] = ko_count_per_bin_df.index
 
-    logging.debug("Calculating completeness of pathways and modules.")
-    logging.debug("Calculating pathway completeness information")
-    KO_pathways = KeggCalc.calculate_KO_group("KO_Pathways", ko_count_per_bin_df.copy())
+    # --- Calculate higher-level completeness ---
+    logging.debug("Calculating completeness of pathways, categories, and modules.")
+    KO_pathways = calculate_KO_group(KeggCalc, "KO_Pathways", ko_count_per_bin_df)
+    KO_categories = calculate_KO_group(KeggCalc, "KO_Categories", ko_count_per_bin_df)
 
-    logging.debug("Calculating category completeness information")
-    KO_categories = KeggCalc.calculate_KO_group(
-        "KO_Categories", ko_count_per_bin_df.copy()
-    )
+    KO_modules = calculate_module_completeness(KeggCalc, ko_count_per_bin_df)
 
-    logging.debug("Calculating module completeness information")
-    KO_modules = KeggCalc.calculate_module_completeness(ko_count_per_bin_df.copy())
-
+    # --- Concatenate results ---
     diamond_complete_results = pd.concat(
         [ko_count_per_bin_df, KO_pathways, KO_modules, KO_categories], axis=1
     )
@@ -128,19 +143,118 @@ def get_diamond_feature_per_bin_df(
     return diamond_complete_results, len(defaultKOs)
 
 
-def prepare_contig_sizes(contig_to_size: Dict[int, int]):
+def calculate_KO_group(
+    KeggCalc: keggData.KeggCalculator, group: str, KO_gene_data: pd.DataFrame
+) -> pd.DataFrame:
     """
-    Prepare a numpy array of contig sizes for fast access.
+    Calculate the completeness of KEGG feature groups per bin.
+
+    :param KeggCalc: An instance of KeggCalculator containing KEGG mappings.
+    :param group: Feature group name (e.g., "KO_Pathways", "KO_Categories").
+    :param KO_gene_data: DataFrame containing KO counts per bin with last column "Name".
+
+    :return: DataFrame with completeness values for each feature vector in the group.
     """
 
+    # last column is 'Name'
+    data = KO_gene_data.drop(columns=["Name"]).values
+    n_bins = data.shape[0]
+
+    # Build output DataFrame
+    ordered_entries = KeggCalc.return_default_values_from_category(group)
+    feature_vectors = list(ordered_entries.keys())
+    n_features = len(feature_vectors)
+
+    # Create empty numpy array for results
+    result = np.zeros((n_bins, n_features), dtype=float)
+
+    # Map Kegg_IDs to column indices in KO_gene_data
+    col_map = {ko: idx for idx, ko in enumerate(KO_gene_data.columns[:-1])}
+
+    for f_idx, vector in enumerate(feature_vectors):
+        # KOs belonging to this feature vector
+        kegg_ids = KeggCalc.path_category_mapping.loc[
+            KeggCalc.path_category_mapping[group] == vector, "Kegg_ID"
+        ].values
+
+        # Only keep KOs present in DataFrame columns
+        present_cols = [col_map[ko] for ko in kegg_ids if ko in col_map]
+        if not present_cols:
+            continue
+
+        # Presence/absence: values >1 -> 1
+        vals = data[:, present_cols]
+        vals[vals > 1] = 1
+        result[:, f_idx] = vals.sum(axis=1) / len(kegg_ids)
+
+    return pd.DataFrame(result, columns=feature_vectors, index=KO_gene_data.index)
+
+
+def calculate_module_completeness(
+    KeggCalc: keggData.KeggCalculator, KO_gene_data: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Compute module completeness per bin using NumPy for speed.
+
+    :param KeggCalc: An instance of KeggCalculator containing module definitions.
+    :param KO_gene_data: DataFrame containing KO counts per bin with last column "Name".
+
+    :return: DataFrame with completeness values for each module.
+    """
+    data = KO_gene_data.drop(columns=["Name"]).values
+    n_bins = data.shape[0]
+
+    modules = list(KeggCalc.module_definitions.keys())
+    n_modules = len(modules)
+
+    # Map KO names to column indices
+    col_map = {
+        ko: idx for idx, ko in enumerate(KO_gene_data.drop(columns=["Name"]).columns)
+    }
+
+    # Prepare result array
+    result = np.zeros((n_bins, n_modules), dtype=float)
+
+    for m_idx, module in enumerate(modules):
+        # Only keep KOs that exist in the DataFrame
+
+        module_kos = [ko for ko in KeggCalc.module_definitions[module] if ko in col_map]
+        if not module_kos:
+            continue
+        cols = [col_map[ko] for ko in module_kos]
+
+        vals = data[:, cols]
+        # vals[vals > 1] = 1  # presence/absence
+
+        result[:, m_idx] = vals.sum(axis=1) / len(KeggCalc.module_definitions[module])
+
+    return pd.DataFrame(result, columns=modules, index=KO_gene_data.index)
+
+
+def prepare_contig_sizes(contig_to_size: Dict[int, int]) -> np.ndarray:
+    """
+    Prepare a numpy array of contig sizes for fast access.
+
+    :param contig_to_size: Dictionary mapping contig IDs to contig sizes.
+
+    :return: Numpy array where the index corresponds to the contig ID
+             and the value is the contig size.
+    """
     max_id = max(contig_to_size)
     contig_sizes = np.zeros(max_id + 1, dtype=np.int64)
-    for cid, size in contig_to_size.items():
-        contig_sizes[cid] = size
+    for contig_id, size in contig_to_size.items():
+        contig_sizes[contig_id] = size
     return contig_sizes
 
 
 def compute_N50(lengths: np.ndarray) -> int:
+    """
+    Compute the N50 value for a given set of contig lengths.
+
+    :param lengths: Numpy array of contig lengths.
+
+    :return: N50 value (contig length at which 50% of the genome is covered).
+    """
     arr = np.sort(lengths)
     half = arr.sum() / 2
     csum = np.cumsum(arr)
@@ -149,10 +263,12 @@ def compute_N50(lengths: np.ndarray) -> int:
 
 def add_bin_size_and_N50(bins: Iterable[Bin], contig_to_size: Dict[int, int]):
     """
-    Add bin size and N50 to a list of bin objects.
+    Add bin size and N50 metrics to a list of bin objects.
 
     :param bins: List of bin objects.
-    :param contig_to_size: Dictionary mapping contig names to their sizes.
+    :param contig_to_size: Dictionary mapping contig IDs to contig sizes.
+
+    :return: None. The bin objects are updated in place with size and N50.
     """
     # TODO use numpy array everywhere instead of contig_to_size
     contig_sizes = prepare_contig_sizes(contig_to_size)
@@ -171,6 +287,7 @@ def add_bin_metrics(
     contig_info: Dict,
     contamination_weight: float,
     threads: int = 1,
+    chunk_size: int = 5000,
 ):
     """
     Add metrics to a Set of bins.
@@ -179,6 +296,7 @@ def add_bin_metrics(
     :param contig_info: Dictionary containing contig information.
     :param contamination_weight: Weight for contamination assessment.
     :param threads: Number of threads for parallel processing (default is 1).
+    :param chunk_size: Number of bins to process in each chunk (default is 5000).
 
     :return: List of processed bin objects.
     """
@@ -189,10 +307,7 @@ def add_bin_metrics(
     contig_to_aa_counter = contig_info["contig_to_aa_counter"]
     contig_to_aa_length = contig_info["contig_to_aa_length"]
 
-    logging.info("Getting bin length and N50")
-
     logging.info(f"Assessing bin quality for {len(bins)} bins.")
-
     assess_bins_quality_by_chunk(
         bins,
         contig_to_kegg_counter,
@@ -201,7 +316,7 @@ def add_bin_metrics(
         contig_to_aa_length,
         contamination_weight,
         postProcessor,
-        chunk_size=1000,
+        chunk_size=chunk_size,
     )
     return bins
 

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -7,7 +7,7 @@ from typing import Dict, Iterable, Optional, Tuple, Iterator, List
 
 import numpy as np
 import pandas as pd
-from binette.bin_manager import Bin, BitmapBin
+from binette.bin_manager import Bin
 from tqdm import tqdm
 
 # Suppress unnecessary TensorFlow warnings
@@ -19,7 +19,7 @@ from checkm2 import keggData, modelPostprocessing, modelProcessing  # noqa: E402
 
 
 def get_bins_metadata_df(
-    bins: List[BitmapBin],
+    bins: List[Bin],
     contig_to_cds_count: Dict[str, int],
     contig_to_aa_counter: Dict[str, Counter],
     contig_to_aa_length: Dict[str, int],
@@ -76,7 +76,7 @@ def get_bins_metadata_df(
 
 
 def get_diamond_feature_per_bin_df(
-    bins: List[BitmapBin], contig_to_kegg_counter: Dict[str, Counter]
+    bins: List[Bin], contig_to_kegg_counter: Dict[str, Counter]
 ) -> Tuple[pd.DataFrame, int]:
     """
     Generate a DataFrame containing Diamond feature counts per bin and completeness information for pathways, categories, and modules.

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -213,7 +213,7 @@ def get_contig_cds_metadata(
 
 
 def filter_faa_file(
-    contigs_to_keep: Set[str],
+    contigs_to_keep: List[str],
     input_faa_file: Path,
     filtered_faa_file: Path,
 ):
@@ -249,7 +249,7 @@ def filter_faa_file(
     # Calculate metrics
     total_contigs = len(contigs_to_keep)
     contigs_with_no_genes = total_contigs - len(contigs_with_genes)
-    contigs_not_in_keep_list = len(contigs_parsed - contigs_to_keep)
+    contigs_not_in_keep_list = len(contigs_parsed - set(contigs_to_keep))
 
     # Log the computed metrics
     logging.info(f"Processing protein sequences from '{input_faa_file}'.")

--- a/binette/contig_manager.py
+++ b/binette/contig_manager.py
@@ -1,5 +1,5 @@
 import pyfastx
-from typing import Dict, Iterable, Tuple, Set, Any, Union
+from typing import Dict, Iterable, Set, Any, Union
 
 
 def parse_fasta_file(fasta_file: str, index_file: str) -> pyfastx.Fasta:
@@ -14,7 +14,7 @@ def parse_fasta_file(fasta_file: str, index_file: str) -> pyfastx.Fasta:
     return fa
 
 
-def make_contig_index(contigs: Set[str]) -> Tuple[Dict[str, int], Dict[int, str]]:
+def make_contig_index(contigs: Set[str]) -> Dict[str, int]:
     """
     Create an index mapping for contigs.
 
@@ -23,8 +23,7 @@ def make_contig_index(contigs: Set[str]) -> Tuple[Dict[str, int], Dict[int, str]
     :return: A tuple containing the contig index mapping dictionaries (contig_to_index, index_to_contig).
     """
     contig_to_index = {contig: index for index, contig in enumerate(contigs)}
-    index_to_contig = {index: contig for contig, index in contig_to_index.items()}
-    return contig_to_index, index_to_contig
+    return contig_to_index
 
 
 def apply_contig_index(

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import logging
+from operator import length_hint
 from typing import Iterable, List, Dict, Tuple, Set
 import csv
 
@@ -199,6 +200,10 @@ def write_bins_fasta(
             contig_name = contigs_names[contig_id]
             contig_to_bins[contig_name] = sbin.name
 
+    assert len(contig_to_bins) == sum(
+        len(sbin.contigs) for sbin in selected_bins
+    ), "Some contigs are present in multiple bins but should be unique."
+
     buffer = defaultdict(list)
     buffer_size = 0
 
@@ -282,7 +287,7 @@ def check_resume_file(faa_file: Path, diamond_result_file: Path) -> None:
         raise FileNotFoundError(error_msg)
 
 
-def write_original_bin_metrics(original_bins: Set[Bin], original_bin_report_dir: Path):
+def write_original_bin_metrics(original_bins: List[Bin], original_bin_report_dir: Path):
     """
     Write metrics of original input bins to a specified directory.
 

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -123,9 +123,10 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
     """
 
     header = [
-        "bin_id",
-        "origin",
         "name",
+        "origin",
+        "is_original",
+        "original_name",
         "completeness",
         "contamination",
         "score",
@@ -137,14 +138,19 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
         header.append("contigs")
 
     bin_infos = []
-    for bin_obj in sorted(bins, key=lambda x: (x.score, x.N50, -x.id), reverse=True):
+    for bin_obj in sorted(
+        bins, key=lambda x: (-x.score, -x.N50, -x.is_original, x.contigs_key)
+    ):
+        original_name = bin_obj.original_name if bin_obj.original_name else bin_obj.name
+        origins = bin_obj.origin if bin_obj.is_original else {"binette"}
         bin_info = [
-            bin_obj.id,
-            ";".join(bin_obj.origin),
             bin_obj.name,
+            ";".join(origins),
+            bin_obj.is_original,
+            original_name,
             bin_obj.completeness,
             bin_obj.contamination,
-            bin_obj.score,
+            round(bin_obj.score, 2),
             bin_obj.length,
             bin_obj.N50,
             len(bin_obj.contigs),
@@ -163,9 +169,10 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
 
 
 def write_bins_fasta(
-    selected_bins: List,
+    selected_bins: List[Bin],
     contigs_fasta: Path,
     outdir: Path,
+    contigs_names: List[str],
     max_buffer_size: int = 50_000_000,
 ):
     """
@@ -181,37 +188,38 @@ def write_bins_fasta(
 
     # Clear existing files for selected bins
     for sbin in selected_bins:
-        out_path = outdir / f"bin_{sbin.id}.fa"
+        out_path = outdir / f"{sbin.name}.fa"
         if out_path.exists():
             out_path.unlink()  # remove the file
 
     # Map contig name to bin IDs
     contig_to_bins = {}
     for sbin in selected_bins:
-        for contig in sbin.contigs:
-            contig_to_bins[contig] = sbin.id
+        for contig_id in sbin.contigs:
+            contig_name = contigs_names[contig_id]
+            contig_to_bins[contig_name] = sbin.name
 
     buffer = defaultdict(list)
     buffer_size = 0
 
     def flush_buffer():
         nonlocal buffer_size
-        for bin_id, seqs in buffer.items():
+        for bin_name, seqs in buffer.items():
             if seqs:
-                with open(outdir / f"bin_{bin_id}.fa", "a") as f:
+                with open(outdir / f"{bin_name}.fa", "a") as f:
                     f.writelines(seqs)
         buffer.clear()
         buffer_size = 0
 
     for name, seq in pyfastx.Fastx(contigs_fasta.as_posix()):
-        bin_id = contig_to_bins.get(name)
-        if not bin_id:
+        bin_name = contig_to_bins.get(name)
+        if not bin_name:
             continue
 
         fasta_entry = f">{name}\n{seq}\n"
         entry_size = len(fasta_entry)
 
-        buffer[bin_id].append(fasta_entry)
+        buffer[bin_name].append(fasta_entry)
 
         buffer_size += entry_size
         if buffer_size >= max_buffer_size:
@@ -287,10 +295,10 @@ def write_original_bin_metrics(original_bins: Set[Bin], original_bin_report_dir:
 
     original_bin_report_dir.mkdir(parents=True, exist_ok=True)
 
-    bin_set_name_to_bins = defaultdict(set)
+    bin_set_name_to_bins = defaultdict(list)
     for bin_obj in original_bins:
         for origin in bin_obj.origin:
-            bin_set_name_to_bins[origin].add(bin_obj)
+            bin_set_name_to_bins[origin].append(bin_obj)
 
     for i, (set_name, bins) in enumerate(sorted(bin_set_name_to_bins.items())):
         bins_metric_file = (

--- a/binette/main.py
+++ b/binette/main.py
@@ -213,6 +213,7 @@ def parse_arguments(args):
     filter_group.add_argument(
         "-w",
         "--contamination-weight",
+        "--contamination_weight",
         default=2,
         type=float,
         help="Bins are scored as: completeness - weight * contamination. "
@@ -227,6 +228,7 @@ def parse_arguments(args):
     advanced_group.add_argument(
         "-e",
         "--fasta-extensions",
+        "--fasta_extensions",
         nargs="+",
         default={".fasta", ".fa", ".fna"},
         type=str,
@@ -235,6 +237,7 @@ def parse_arguments(args):
 
     advanced_group.add_argument(
         "--checkm2-db",
+        "--checkm2_db",
         type=Path,
         help="Path to CheckM2 diamond database. "
         "By default the database set via <checkm2 database> is used.",

--- a/binette/main.py
+++ b/binette/main.py
@@ -95,6 +95,7 @@ def is_valid_file(parser: ArgumentParser, arg: str) -> Path:
 
     return path_arg
 
+
 def parse_arguments(args):
     """Parse script arguments."""
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -567,10 +567,11 @@ def main():
 
     logging.info("Create intermediate bins:")
     new_bins = bin_manager.create_intermediate_bins(original_bins)
-
     print("STOP HERE")
     return 0
+
     logging.info(f"Assess quality for {len(new_bins)} intermediate bins.")
+
     bin_quality.add_bin_metrics(
         new_bins,
         contig_metadat,

--- a/binette/main.py
+++ b/binette/main.py
@@ -26,7 +26,7 @@ from binette import (
 from typing import List, Dict, Optional, Set, Tuple, Union, Sequence, Any
 from pathlib import Path
 import pyfastx
-
+from pyroaring import BitMap
 
 def init_logging(verbose, debug):
     """Initialise logging."""
@@ -155,6 +155,13 @@ def parse_arguments(args):
     )
 
     other_group.add_argument(
+        "--max_contamination",
+        default=10,
+        type=int,
+        help="Maximum contamination required for final bin selections.",
+    )
+
+    other_group.add_argument(
         "-t", "--threads", default=1, type=int, help="Number of threads to use."
     )
 
@@ -215,9 +222,7 @@ def parse_input_files(
     contig2bin_tables: List[Path],
     contigs_fasta: Path,
     fasta_extensions: Set[str] = {".fasta", ".fna", ".fa"},
-) -> Tuple[
-    Dict[str, Set[bin_manager.Bin]], Set[bin_manager.Bin], Set[str], Dict[str, int]
-]:
+):
     """
     Parses input files to retrieve information related to bins and contigs.
 
@@ -225,7 +230,7 @@ def parse_input_files(
     :param contig2bin_tables: List of paths to contig-to-bin tables.
     :param contigs_fasta: Path to the contigs FASTA file.
     :param temporary_dir: Path to the temporary directory to store intermediate files.
-    :fasta_extensions: Possible fasta extensions to look for in the bin directory.
+    :param fasta_extensions: Possible fasta extensions to look for in the bin directory.
 
     :return: A tuple containing:
         - List of original bins.
@@ -236,7 +241,7 @@ def parse_input_files(
     if bin_dirs:
         logging.info("Parsing bin directories.")
         bin_name_to_bin_dir = io.infer_bin_set_names_from_input_paths(bin_dirs)
-        bin_set_name_to_bins = bin_manager.parse_bin_directories(
+        bin_set_name_to_bins_info = bin_manager.parse_bin_directories(
             bin_name_to_bin_dir, fasta_extensions
         )
     else:
@@ -244,17 +249,23 @@ def parse_input_files(
         bin_name_to_bin_table = io.infer_bin_set_names_from_input_paths(
             contig2bin_tables
         )
-        bin_set_name_to_bins = bin_manager.parse_contig2bin_tables(
+        bin_set_name_to_bins_info = bin_manager.parse_contig2bin_tables(
             bin_name_to_bin_table
         )
 
-    logging.info(f"Processing {len(bin_set_name_to_bins)} bin sets.")
-    for bin_set_id, bins in bin_set_name_to_bins.items():
-        logging.info(f" {bin_set_id} - {len(bins)} bins")
+    logging.info(f"Processing {len(bin_set_name_to_bins_info)} bin sets.")
+    for bin_set_id, bins_info in bin_set_name_to_bins_info.items():
+        logging.info(f" {bin_set_id} - {len(bins_info)} bins")
 
-    contigs_in_bins = bin_manager.get_contigs_in_bin_sets(bin_set_name_to_bins)
+    contigs_in_bins = bin_manager.get_contigs_in_bin_sets(bin_set_name_to_bins_info)
 
-    original_bins = bin_manager.dereplicate_bin_sets(bin_set_name_to_bins.values())
+    contig_to_index = contig_manager.make_contig_index(contigs_in_bins)
+
+    contig_key_to_bin = bin_manager.make_bins_from_bins_info(
+        bin_set_name_to_bins_info, contig_to_index, are_original_bins=True
+    )
+
+    # original_bins = bin_manager.dereplicate_bin_sets(bin_set_name_to_bins.values())
 
     logging.info(f"Parsing contig fasta file: {contigs_fasta}")
 
@@ -275,13 +286,20 @@ def parse_input_files(
             f"The missing contigs are: {', '.join(unexpected_contigs)}. Please ensure all contigs from input bins are present in contig file."
         )
 
-    return original_bins, contigs_in_bins, contig_to_length
+    contig_id_to_length = {
+        contig_to_index[name]: length for name, length in contig_to_length.items()
+    }
+    return (
+        contig_key_to_bin,
+        contigs_in_bins,
+        contig_id_to_length,
+        contig_to_index,
+    )
 
 
 def manage_protein_alignement(
     faa_file: Path,
     contigs_fasta: Path,
-    contig_to_length: Dict[str, int],
     contigs_in_bins: Set[str],
     diamond_result_file: Path,
     checkm2_db: Optional[Path],
@@ -295,7 +313,6 @@ def manage_protein_alignement(
 
     :param faa_file: The path to the .faa file.
     :param contigs_fasta: The path to the contigs FASTA file.
-    :param contig_to_length: Dictionary mapping contig names to their lengths.
     :param contigs_in_bins: Dictionary mapping bin names to lists of contigs.
     :param diamond_result_file: The path to the diamond result file.
     :param checkm2_db: The path to the CheckM2 database.
@@ -312,7 +329,7 @@ def manage_protein_alignement(
         logging.info(f"Parsing faa file: {faa_file}.")
         contig_to_genes = cds.parse_faa_file(faa_file.as_posix())
         io.check_contig_consistency(
-            contig_to_length,
+            contigs_in_bins,
             contig_to_genes,
             contigs_fasta.as_posix(),
             faa_file.as_posix(),
@@ -356,7 +373,7 @@ def manage_protein_alignement(
 
     # Check contigs from diamond vs input assembly consistency
     io.check_contig_consistency(
-        contig_to_length,
+        contigs_in_bins,
         contig_to_kegg_counter,
         contigs_fasta.as_posix(),
         diamond_result_file.as_posix(),
@@ -365,63 +382,21 @@ def manage_protein_alignement(
     return contig_to_kegg_counter, contig_to_genes
 
 
-def select_bins_and_write_them(
-    all_bins: Set[bin_manager.Bin],
+def write_bins_fasta(
+    selected_bins: List[bin_manager.Bin],
     contigs_fasta: Path,
-    final_bin_report: Path,
-    min_completeness: float,
-    index_to_contig: dict,
+    contigs_in_bins: dict,
     outdir: Path,
-    temporary_dir: Path,
-    debug: bool,
-) -> List[bin_manager.Bin]:
-    """
-    Selects and writes bins based on specific criteria.
-
-    :param all_bins: Set of Bin objects.
-    :param contigs_fasta: Path to the contigs FASTA file.
-    :param final_bin_report: Path to write the final bin report.
-    :param min_completeness: Minimum completeness threshold for bin selection.
-    :param index_to_contig: Dictionary mapping indices to contig names.
-    :param outdir: Output directory to save final bins and reports.
-    :param temporary_dir: Path to the temporary directory to store intermediate files.
-    :param debug: Debug mode flag.
-    :return: Selected bins that meet the completeness threshold.
-    """
-
-    outdir_final_bin_set = outdir / "final_bins"
-    os.makedirs(outdir_final_bin_set, exist_ok=True)
-
-    logging.info(
-        f"Filtering bins: only bins with completeness >= {min_completeness} are kept"
-    )
-    all_bins_complete_enough = {
-        b for b in all_bins if b.is_complete_enough(min_completeness)
-    }
-
-    logging.info("Selecting best bins")
-    selected_bins = bin_manager.select_best_bins(all_bins_complete_enough)
-
-    logging.info(f"Bin Selection: {len(selected_bins)} selected bins")
-
-    logging.info(f"Writing selected bins in {final_bin_report}")
+):
 
     for b in selected_bins:
-        b.contigs = {index_to_contig[c_index] for c_index in b.contigs}
+        b.contigs = {contigs_in_bins[c_index] for c_index in b.contigs}
 
-    io.write_bin_info(selected_bins, final_bin_report)
+    outdir_final_bin_set = outdir / "final_bins"
 
-    io.write_bins_fasta(selected_bins, contigs_fasta, outdir_final_bin_set)
-
-    if debug:
-        all_bin_compo_file = outdir / "all_bins_quality_reports.tsv"
-
-        logging.info(f"Writing all bins in {all_bin_compo_file}")
-
-        io.write_bin_info(all_bins, all_bin_compo_file, add_contigs=True)
-
-        with open(os.path.join(outdir, "index_to_contig.tsv"), "w") as flout:
-            flout.write("\n".join((f"{i}\t{c}" for i, c in index_to_contig.items())))
+    io.write_bins_fasta(
+        selected_bins, contigs_fasta, outdir_final_bin_set, contigs_in_bins
+    )
 
     return selected_bins
 
@@ -485,6 +460,8 @@ def main():
     hq_max_conta = 5
     hq_min_completeness = 90
 
+    write_final_fasta_bins = True
+
     # Temporary files #
     out_tmp_dir: Path = args.outdir / "temporary_files"
     os.makedirs(out_tmp_dir, exist_ok=True)
@@ -503,12 +480,25 @@ def main():
         io.check_resume_file(faa_file, diamond_result_file)
         use_existing_protein_file = True
 
-    original_bins, contigs_in_bins, contig_to_length = parse_input_files(
+    (
+        contig_key_to_original_bin,
+        contigs_in_bins,
+        contig_to_length,
+        contig_to_index,
+    ) = parse_input_files(
         args.bin_dirs,
         args.contig2bin_tables,
         args.contigs,
         fasta_extensions=set(args.fasta_extensions),
     )
+
+    if args.debug:
+        index_to_contig_file = args.outdir / "index_to_contig.tsv"
+        logging.info(f"Writing index to contig mapping in {index_to_contig_file}")
+        with open(index_to_contig_file, "w") as flout:
+            flout.write("\n".join((f"{i}\t{c}" for i, c in enumerate(contigs_in_bins))))
+
+    original_bins = list(contig_key_to_original_bin.values())
 
     if args.proteins and not args.resume:
         logging.info(f"Using the provided protein sequences file: {args.proteins}")
@@ -520,10 +510,9 @@ def main():
             filtered_faa_file=faa_file,
         )
 
-    contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
+    contig_name_to_kegg_counter, contig_name_to_genes = manage_protein_alignement(
         faa_file=faa_file,
         contigs_fasta=args.contigs,
-        contig_to_length=contig_to_length,
         contigs_in_bins=contigs_in_bins,
         diamond_result_file=diamond_result_file,
         checkm2_db=args.checkm2_db,
@@ -533,20 +522,12 @@ def main():
         low_mem=args.low_mem,
     )
 
-    # Use contig index instead of contig name to save memory
-    contig_to_index, index_to_contig = contig_manager.make_contig_index(contigs_in_bins)
-
     contig_to_kegg_counter = contig_manager.apply_contig_index(
-        contig_to_index, contig_to_kegg_counter
+        contig_to_index, contig_name_to_kegg_counter
     )
     contig_to_genes = contig_manager.apply_contig_index(
-        contig_to_index, contig_to_genes
+        contig_to_index, contig_name_to_genes
     )
-    contig_to_length = contig_manager.apply_contig_index(
-        contig_to_index, contig_to_length
-    )
-
-    bin_manager.rename_bin_contigs(original_bins, contig_to_index)
 
     # Extract cds metadata ##
     logging.info("Compute cds metadata.")
@@ -559,6 +540,7 @@ def main():
     bin_quality.add_bin_metrics(
         original_bins, contig_metadat, args.contamination_weight, args.threads
     )
+    bin_quality.add_bin_size_and_N50(original_bins, contig_to_length)
 
     logging.info(
         f"Writting original input bin metrics to directory: {original_bin_report_dir}"
@@ -566,32 +548,47 @@ def main():
     io.write_original_bin_metrics(original_bins, original_bin_report_dir)
 
     logging.info("Create intermediate bins:")
-    new_bins = bin_manager.create_intermediate_bins(original_bins)
-    print("STOP HERE")
-    return 0
 
-    logging.info(f"Assess quality for {len(new_bins)} intermediate bins.")
+    contig_key_to_new_bin = bin_manager.create_intermediate_bins(
+        contig_key_to_original_bin
+    )
+
+    logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")
 
     bin_quality.add_bin_metrics(
-        new_bins,
+        contig_key_to_new_bin.values(),
         contig_metadat,
         args.contamination_weight,
         args.threads,
     )
 
-    logging.info("Dereplicating input bins and new bins")
-    all_bins = original_bins | new_bins
+    contig_key_to_all_bin = contig_key_to_original_bin | contig_key_to_new_bin
 
-    selected_bins = select_bins_and_write_them(
-        all_bins=all_bins,
-        contigs_fasta=args.contigs,
-        final_bin_report=final_bin_report,
+    bin_quality.add_bin_size_and_N50(contig_key_to_all_bin.values(), contig_to_length)
+
+    if args.debug:
+        all_bin_compo_file = args.outdir / "all_bins_quality_reports.tsv"
+        logging.info(f"Writing all bins in {all_bin_compo_file}")
+        io.write_bin_info(
+            contig_key_to_all_bin.values(), all_bin_compo_file, add_contigs=True
+        )
+
+    selected_bins = bin_manager.select_best_bins(
+        contig_key_to_all_bin,
         min_completeness=args.min_completeness,
-        index_to_contig=index_to_contig,
-        outdir=args.outdir,
-        temporary_dir=out_tmp_dir,
-        debug=args.debug,
+        max_contamination=args.max_contamination,
     )
+
+    logging.info(f"Writing selected bins in {final_bin_report}")
+    io.write_bin_info(selected_bins, output=final_bin_report)
+
+    if write_final_fasta_bins:
+        io.write_bins_fasta(
+            selected_bins,
+            args.contigs,
+            outdir=args.outdir / "final_bins",
+            contigs_names=contigs_in_bins,
+        )
 
     log_selected_bin_info(selected_bins, hq_min_completeness, hq_max_conta)
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -253,6 +253,7 @@ def parse_input_files(
         logging.info(f" {bin_set_id} - {len(bins)} bins")
 
     contigs_in_bins = bin_manager.get_contigs_in_bin_sets(bin_set_name_to_bins)
+
     original_bins = bin_manager.dereplicate_bin_sets(bin_set_name_to_bins.values())
 
     logging.info(f"Parsing contig fasta file: {contigs_fasta}")
@@ -567,6 +568,8 @@ def main():
     logging.info("Create intermediate bins:")
     new_bins = bin_manager.create_intermediate_bins(original_bins)
 
+    print("STOP HERE")
+    return 0
     logging.info(f"Assess quality for {len(new_bins)} intermediate bins.")
     bin_quality.add_bin_metrics(
         new_bins,

--- a/binette/main.py
+++ b/binette/main.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pyfastx
 from pyroaring import BitMap
 
+
 def init_logging(verbose, debug):
     """Initialise logging."""
     if debug:

--- a/binette/main.py
+++ b/binette/main.py
@@ -556,8 +556,15 @@ def main():
 
     logging.info("Create intermediate bins:")
 
+    contig_lengths = bin_quality.prepare_contig_sizes(contig_to_length)
+
     contig_key_to_new_bin = bin_manager.create_intermediate_bins(
-        contig_key_to_original_bin
+        contig_key_to_original_bin,
+        contig_lengths=contig_lengths,
+        min_comp=args.min_completeness,
+        max_conta=args.max_contamination,
+        min_len=200_000,
+        max_len=10_000_000,
     )
 
     logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")

--- a/binette/main.py
+++ b/binette/main.py
@@ -95,7 +95,6 @@ def is_valid_file(parser: ArgumentParser, arg: str) -> Path:
 
     return path_arg
 
-
 def parse_arguments(args):
     """Parse script arguments."""
 
@@ -104,13 +103,15 @@ def parse_arguments(args):
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
 
-    # Input arguments category
+    # ------------------------
+    # Input arguments
+    # ------------------------
     input_group = parser.add_argument_group("Input Arguments")
     input_arg = input_group.add_mutually_exclusive_group(required=True)
 
     input_arg.add_argument(
         "-d",
-        "--bin_dirs",
+        "--bin-dirs",
         nargs="+",
         type=lambda x: is_valid_file(parser, x),
         action=UniqueStore,
@@ -119,12 +120,12 @@ def parse_arguments(args):
 
     input_arg.add_argument(
         "-b",
-        "--contig2bin_tables",
+        "--contig2bin-tables",
         nargs="+",
         action=UniqueStore,
         type=lambda x: is_valid_file(parser, x),
-        help="List of contig2bin table with two columns separated\
-            with a tabulation: contig, bin",
+        help="List of contig2bin tables with two columns separated "
+        "by a tabulation: contig, bin.",
     )
 
     input_group.add_argument(
@@ -132,7 +133,7 @@ def parse_arguments(args):
         "--contigs",
         required=True,
         type=lambda x: is_valid_file(parser, x),
-        help="Contigs in fasta format.",
+        help="Contigs in FASTA format.",
     )
 
     input_group.add_argument(
@@ -143,78 +144,107 @@ def parse_arguments(args):
         "Skips the gene prediction step if provided.",
     )
 
-    # Other parameters category
-    other_group = parser.add_argument_group("Other Arguments")
+    # ------------------------
+    # Output & runtime control
+    # ------------------------
+    runtime_group = parser.add_argument_group("Output and Runtime Control")
 
-    other_group.add_argument(
-        "-m",
-        "--min_completeness",
-        default=40,
-        type=int,
-        help="Minimum completeness required for final bin selections.",
-    )
-
-    other_group.add_argument(
-        "--max_contamination",
-        default=10,
-        type=int,
-        help="Maximum contamination required for final bin selections.",
-    )
-
-    other_group.add_argument(
-        "-t", "--threads", default=1, type=int, help="Number of threads to use."
-    )
-
-    other_group.add_argument(
+    runtime_group.add_argument(
         "-o", "--outdir", default=Path("results"), type=Path, help="Output directory."
     )
 
-    other_group.add_argument(
-        "-w",
-        "--contamination_weight",
-        default=2,
-        type=float,
-        help="Bin are scored as follow: completeness - weight * contamination. "
-        "A low contamination_weight favor complete bins over low contaminated bins.",
+    runtime_group.add_argument(
+        "-t", "--threads", default=1, type=int, help="Number of threads to use."
     )
 
-    other_group.add_argument(
+    runtime_group.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume mode: reuse existing temporary files if possible.",
+    )
+
+    runtime_group.add_argument(
+        "-v", "--verbose", help="Increase output verbosity.", action="store_true"
+    )
+
+    runtime_group.add_argument(
+        "--debug", help="Activate debug mode.", action="store_true"
+    )
+
+    runtime_group.add_argument(
+        "--version", action="version", version=binette.__version__
+    )
+
+    # ------------------------
+    # Bin filtering & scoring
+    # ------------------------
+    filter_group = parser.add_argument_group("Bin Filtering and Scoring")
+
+    filter_group.add_argument(
+        "--min-completeness",
+        "--min_completeness",
+        default=40,
+        type=int,
+        help="Minimum completeness required for intermediate bin creation and final bin selection.",
+    )
+
+    filter_group.add_argument(
+        "--max-contamination",
+        "--max_contamination",
+        default=10,
+        type=int,
+        help="Maximum contamination allowed for intermediate bin creation and final bin selection.",
+    )
+
+    filter_group.add_argument(
+        "--min-length",
+        default=200_000,
+        type=int,
+        help="Minimum length (bp) required for intermediate bin creation and final bin selection.",
+    )
+
+    filter_group.add_argument(
+        "--max-length",
+        default=10_000_000,
+        type=int,
+        help="Maximum length (bp) allowed for intermediate bin creation and final bin selection.",
+    )
+
+    filter_group.add_argument(
+        "-w",
+        "--contamination-weight",
+        default=2,
+        type=float,
+        help="Bins are scored as: completeness - weight * contamination. "
+        "A lower weight favors completeness over low contamination.",
+    )
+
+    # ------------------------
+    # Advanced options
+    # ------------------------
+    advanced_group = parser.add_argument_group("Advanced Options")
+
+    advanced_group.add_argument(
         "-e",
-        "--fasta_extensions",
+        "--fasta-extensions",
         nargs="+",
         default={".fasta", ".fa", ".fna"},
         type=str,
-        help="Specify the FASTA file extensions to search for in bin directories when using the --bin_dirs option.",
+        help="FASTA file extensions to search for in bin directories (used with --bin-dirs).",
     )
 
-    other_group.add_argument(
-        "--checkm2_db",
+    advanced_group.add_argument(
+        "--checkm2-db",
         type=Path,
-        help="Provide a path for the CheckM2 diamond database. "
+        help="Path to CheckM2 diamond database. "
         "By default the database set via <checkm2 database> is used.",
     )
 
-    other_group.add_argument(
-        "--low_mem", help="Use low mem mode when running diamond", action="store_true"
+    advanced_group.add_argument(
+        "--low-mem", help="Enable low-memory mode for Diamond.", action="store_true"
     )
 
-    other_group.add_argument(
-        "-v", "--verbose", help="increase output verbosity", action="store_true"
-    )
-
-    other_group.add_argument("--debug", help="Activate debug mode", action="store_true")
-
-    other_group.add_argument(
-        "--resume",
-        action="store_true",
-        help="Activate resume mode. Binette will examine the 'temporary_files' directory "
-        "within the output directory and reuse any existing files if possible.",
-    )
-
-    other_group.add_argument("--version", action="version", version=binette.__version__)
-
-    args = parser.parse_args(args)
-    return args
+    return parser.parse_args(args)
 
 
 def parse_input_files(
@@ -563,8 +593,8 @@ def main():
         contig_lengths=contig_lengths,
         min_comp=args.min_completeness,
         max_conta=args.max_contamination,
-        min_len=200_000,
-        max_len=10_000_000,
+        min_len=args.min_length,
+        max_len=args.max_length,
     )
 
     logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")

--- a/binette/main.py
+++ b/binette/main.py
@@ -26,7 +26,6 @@ from binette import (
 from typing import List, Dict, Optional, Set, Tuple, Union, Sequence, Any
 from pathlib import Path
 import pyfastx
-from pyroaring import BitMap
 
 
 def init_logging(verbose, debug):

--- a/binette/main.py
+++ b/binette/main.py
@@ -272,10 +272,11 @@ def parse_input_files(
         f"Parsing contig fasta file to retrieve lengths of contigs: {contigs_fasta}"
     )
 
+    contigs_in_bins_set = set(contigs_in_bins)
     contig_to_length = {
         name: len(seq)
         for name, seq in pyfastx.Fastx(contigs_fasta.as_posix())
-        if name in contigs_in_bins
+        if name in contigs_in_bins_set
     }
 
     logging.debug("Parsing contig fasta is done")

--- a/binette/main.py
+++ b/binette/main.py
@@ -258,6 +258,7 @@ def parse_input_files(
         logging.info(f" {bin_set_id} - {len(bins_info)} bins")
 
     contigs_in_bins = bin_manager.get_contigs_in_bin_sets(bin_set_name_to_bins_info)
+    logging.info(f"Found {len(contigs_in_bins)} contigs in input bins")
 
     contig_to_index = contig_manager.make_contig_index(contigs_in_bins)
 
@@ -267,7 +268,9 @@ def parse_input_files(
 
     # original_bins = bin_manager.dereplicate_bin_sets(bin_set_name_to_bins.values())
 
-    logging.info(f"Parsing contig fasta file: {contigs_fasta}")
+    logging.info(
+        f"Parsing contig fasta file to retrieve lengths of contigs: {contigs_fasta}"
+    )
 
     contig_to_length = {
         name: len(seq)
@@ -275,6 +278,7 @@ def parse_input_files(
         if name in contigs_in_bins
     }
 
+    logging.debug("Parsing contig fasta is done")
     # check if all contigs from input bins are present in contigs file
     unexpected_contigs = {
         contig for contig in contigs_in_bins if contig not in contig_to_length
@@ -285,10 +289,12 @@ def parse_input_files(
             f"{len(unexpected_contigs)} contigs from the input bins were not found in the contigs file '{contigs_fasta}'. "
             f"The missing contigs are: {', '.join(unexpected_contigs)}. Please ensure all contigs from input bins are present in contig file."
         )
+    logging.debug("No unexpected contigs found.")
 
     contig_id_to_length = {
         contig_to_index[name]: length for name, length in contig_to_length.items()
     }
+
     return (
         contig_key_to_bin,
         contigs_in_bins,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,16 +85,18 @@ In this directory you will find:
 
 
 The `final_bins_quality_reports.tsv` file contains the following columns:
-| Column Name         | Description                                                                                                  |
-|---------------------|--------------------------------------------------------------------------------------------------------------|
-| **bin_id**          | This column displays the unique ID of the bin.                                                             |
-| **origin**          | Indicates the source or origin of the bin, specifying from which bin set it originates or the intermediate set operation that created it. |
-| **name**            | The name of the bin.                                                                                        |
-| **completeness**    | The completeness of the bin, determined by CheckM2.                                                         |
-| **contamination**   | The contamination of the bin, determined by CheckM2.                                                       |
-| **score**           | This column displays the computed score, which is calculated as: `completeness - contamination * weight`. You can customize the contamination weight using the `--contamination_weight` option. |
-| **size**            | Represents the size of the bin in nucleotides.                                                              |
-| **N50**             | Displays the N50 of the bin.                                                                                |
-| **contig_count**    | The number of contigs contained within the bin.          
+| Column Name        | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **name**           | The unique name of the bin.                                                                                                                    |
+| **origin**         | Indicates the source of the bin: either an original bin set (e.g., `B`) or `binette` for intermediate bins.                                    |
+| **is\_original**   | Boolean flag indicating if the bin is an original bin (`True`) or an intermediate bin (`False`).                                               |
+| **original\_name** | The name of the original bin from which this bin was derived.                                                                                  |
+| **completeness**   | The completeness of the bin, determined by CheckM2.                                                                                            |
+| **contamination**  | The contamination of the bin, determined by CheckM2.                                                                                           |
+| **score**          | Computed score: `completeness - contamination * weight`. The contamination weight can be customized using the `--contamination_weight` option. |
+| **size**           | Total size of the bin in nucleotides.                                                                                                          |
+| **N50**            | The N50 of the bin, representing the length for which 50% of the total nucleotides are in contigs of that length or longer.                    |
+| **contig\_count**  | Number of contigs contained within the bin.                                                                                                    |
+   
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ main_deps = [
     "pyfastx>=2,<3",
     "pyrodigal>=2,<3",
     "tqdm>=4,<5",
+    "pyroaring>=1.0.0,<2.0.0",
 ]
 
 doc = [

--- a/tests/bin_manager_test.py
+++ b/tests/bin_manager_test.py
@@ -5,7 +5,7 @@ Unit tests for binette.
 
 import pytest
 
-from binette import bin_manager
+from binette import bin_manager, bin_quality
 import networkx as nx
 
 import logging
@@ -287,10 +287,12 @@ def test_intersection_bins_created():
     for b in set1:
         b.completeness = 100
         b.contamination = 0
+        b.length = 7000
 
     binA = bin_manager.Bin(contigs=BitMap({1, 3}), origin="B", name="binA")
     binA.contamination = 0
     binA.completeness = 100
+    binA.length = 7000
     set2 = [
         binA,
     ]
@@ -298,7 +300,18 @@ def test_intersection_bins_created():
 
     key_to_bins = {b.contigs_key: b for b in input_bins}
 
-    intermediate_bins_result = bin_manager.create_intermediate_bins(key_to_bins)
+    contig_lengths = bin_quality.prepare_contig_sizes(
+        {1: 5000, 2: 3000, 3: 4000, 4: 2000, 5: 1000}
+    )
+
+    intermediate_bins_result = bin_manager.create_intermediate_bins(
+        key_to_bins,
+        contig_lengths=contig_lengths,
+        min_len=0,
+        max_len=10_000_000,
+        min_comp=0,
+        max_conta=100,
+    )
 
     expected_bin_compositions = [
         BitMap({1, 2, 3}),

--- a/tests/bin_manager_test.py
+++ b/tests/bin_manager_test.py
@@ -10,7 +10,7 @@ import networkx as nx
 
 import logging
 from pathlib import Path
-
+from pyroaring import BitMap
 
 def test_get_all_possible_combinations():
     input_list = ["2", "3", "4"]
@@ -19,39 +19,24 @@ def test_get_all_possible_combinations():
     assert list(bin_manager.get_all_possible_combinations(input_list)) == expected_list
 
 
-@pytest.fixture
-def example_bin_set1():
-    bin1 = bin_manager.Bin(contigs={"1", "2"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"3", "4"}, origin="test1", name="bin2")
-    bin3 = bin_manager.Bin(contigs={"5"}, origin="test1", name="bin2")
-    return {bin1, bin2, bin3}
-
-
-@pytest.fixture
-def example_bin_set2():
-    bin1 = bin_manager.Bin(contigs={"1", "2", "3"}, origin="test2", name="binA")
-    bin2 = bin_manager.Bin(contigs={"4", "5"}, origin="test2", name="binB")
-    return {bin1, bin2}
-
-
 def test_bin_eq_true():
-    bin1 = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="test2", name="binA")
 
     assert bin1 == bin2
 
 
 def test_bin_eq_false():
-    bin1 = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test2", name="binA")
 
     assert bin1 != bin2
 
 
 def test_in_for_bin_list():
-    bin1 = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
-    bin3 = bin_manager.Bin(contigs={"4", "R"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 33}), origin="test2", name="binA")
+    bin3 = bin_manager.Bin(contigs=BitMap({4, 5}), origin="test2", name="binA")
 
     bins = [bin1, bin2]
 
@@ -61,28 +46,28 @@ def test_in_for_bin_list():
 
 
 def test_add_length_positive_integer():
-    bin_obj = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
+    bin_obj = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
     length = 100
     bin_obj.add_length(length)
     assert bin_obj.length == length
 
 
 def test_add_length_negative_integer():
-    bin_obj = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
+    bin_obj = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
     with pytest.raises(ValueError):
         length = -50
         bin_obj.add_length(length)
 
 
 def test_add_n50_positive_integer():
-    bin_obj = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
+    bin_obj = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
     n50 = 100
     bin_obj.add_N50(n50)
     assert bin_obj.N50 == n50
 
 
 def test_add_n50_negative_integer():
-    bin_obj = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
+    bin_obj = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
     with pytest.raises(ValueError):
         n50 = -50
         bin_obj.add_N50(n50)
@@ -94,7 +79,7 @@ def test_add_quality():
     contamination = 6
     contamination_weight = 2
 
-    bin_obj = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
+    bin_obj = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
 
     bin_obj.add_quality(completeness, contamination, contamination_weight)
 
@@ -104,34 +89,19 @@ def test_add_quality():
     assert bin_obj.score == completeness - contamination * contamination_weight
 
 
-# def test_two_bin_intersection():
-#     bin1 = bin_manager.Bin(contigs={"1", "2", "e", "987"}, origin="test1", name="bin1")
-#     bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
-
-#     bin_intersection = bin1 & bin2
-
-#     assert bin_intersection == bin_manager.Bin({"1", "2", "e"}, "", "")
-
-
 def test_multiple_bins_intersection():
-    bin1 = bin_manager.Bin(contigs={"1", "2", "e", "987"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
-    bin3 = bin_manager.Bin(contigs={"1", "123", "2", "33"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2, 3, 987}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 33}), origin="test2", name="binA")
+    bin3 = bin_manager.Bin(contigs=BitMap({1, 2, 33}), origin="test2", name="binA")
 
-    bin_intersection = bin1.intersection(bin2, bin3)
+    bin_intersection = bin1.contig_intersection(bin2, bin3)
 
-    assert bin_intersection == bin_manager.Bin({"1", "2"}, "", "")
-
-
-def test_bin_set_has_no_duplicate(example_bin_set1):
-    set1_twice = list(example_bin_set1) + list(example_bin_set1)
-
-    assert example_bin_set1 == set(set1_twice)
+    assert bin_intersection == BitMap({1, 2})
 
 
 def test_bin_overlap_true():
-    bin1 = bin_manager.Bin(contigs={"1", "2", "e"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 33}), origin="test2", name="binA")
 
     assert bin1.overlaps_with(bin2)
 
@@ -139,107 +109,119 @@ def test_bin_overlap_true():
 
 
 def test_bin_overlap_false():
-    bin1 = bin_manager.Bin(contigs={"13", "21", "ef"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({13, 21, 37}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 33}), origin="test2", name="binA")
 
     assert not bin1.overlaps_with(bin2)
 
 
 def test_bin_union():
-    bin1 = bin_manager.Bin(contigs={"13", "21"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "e", "2", "33"}, origin="test2", name="binA")
+    bin1 = bin_manager.Bin(contigs=BitMap({13, 21}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 33}), origin="test2", name="binA")
 
-    expected_union_bin = bin_manager.Bin(
-        contigs={"13", "21", "1", "e", "2", "33"}, origin="", name=""
-    )
-    union_bin = bin1.union(bin2)
+    expected_union_bin_composition = BitMap({13, 21, 1, 2, 33})
 
-    assert union_bin == expected_union_bin
-    assert union_bin.name == f"{bin1.id} | {bin2.id}"
+    union_bin = bin1.contig_union(bin2)
+
+    assert union_bin == expected_union_bin_composition
 
 
 def test_bin_union2():
     # Create some example bins
-    bin1 = bin_manager.Bin({"contig1", "contig2"}, "origin1", "bin1")
-    bin2 = bin_manager.Bin({"contig2", "contig3"}, "origin2", "bin2")
-    bin3 = bin_manager.Bin({"contig4", "contig5"}, "origin3", "bin3")
+    bin1 = bin_manager.Bin(BitMap({1, 2}), "origin1", "bin1")
+    bin2 = bin_manager.Bin(BitMap({2, 3}), "origin2", "bin2")
+    bin3 = bin_manager.Bin(BitMap({4, 5}), "origin3", "bin3")
 
     # Perform union operation
-    union_bin = bin1.union(bin2, bin3)
+    union_bin = bin1.contig_union(bin2, bin3)
 
     # Check the result
-    expected_contigs = {"contig1", "contig2", "contig3", "contig4", "contig5"}
-    expected_origin = {"union"}
+    expected_contigs = BitMap({1, 2, 3, 4, 5})
 
-    assert union_bin.contigs == expected_contigs
-    assert union_bin.origin == expected_origin
+    assert union_bin == expected_contigs
 
 
 def test_bin_difference():
-    bin1 = bin_manager.Bin(contigs={5, 1, 6, 7, 8}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={3, 6, 7}, origin="test2", name="bin2")
-    bin3 = bin_manager.Bin(contigs={1, 2, 3, 4}, origin="test2", name="bin3")
+    bin1 = bin_manager.Bin(contigs=BitMap({5, 1, 6, 7, 8}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({3, 6, 7}), origin="test2", name="bin2")
+    bin3 = bin_manager.Bin(contigs=BitMap({1, 2, 3, 4, 6}), origin="test2", name="bin3")
 
-    diff_bin1_23 = bin_manager.Bin(contigs={5, 8}, origin="", name="")
-    diff_bin1_2 = bin_manager.Bin(contigs={5, 1, 8}, origin="", name="")
+    diff_bin1_2_3 = BitMap({6})
+    diff_bin1_2 = BitMap({6, 7})
 
-    assert bin1.difference(bin2, bin3) == diff_bin1_23
-    assert bin1.difference(bin2) == diff_bin1_2
-    assert bin1.difference(bin2, bin3).name == f"{bin1.id} - {bin2.id} - {bin3.id}"
-
+    assert bin1.contig_intersection(bin2, bin3) == diff_bin1_2_3
+    assert bin1.contig_intersection(bin2) == diff_bin1_2
 
 def test_bin_intersection():
-    bin1 = bin_manager.Bin(contigs={5, 1, 6, 7, 8}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={3, 6, 7}, origin="test2", name="bin2")
-    bin3 = bin_manager.Bin(contigs={1, 2, 3, 4, 7}, origin="test2", name="bin3")
+    bin1 = bin_manager.Bin(contigs=BitMap({5, 1, 6, 7, 8}), origin="test1", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({3, 6, 7}), origin="test2", name="bin2")
+    bin3 = bin_manager.Bin(contigs=BitMap({1, 2, 3, 4, 7}), origin="test2", name="bin3")
 
-    inter_bin123 = bin_manager.Bin(contigs={7}, origin="", name="")
-    iner_bin1_2 = bin_manager.Bin(contigs={7, 6}, origin="", name="")
+    inter_bin123 = BitMap({7})
+    inter_bin1_2 = BitMap({7, 6})
 
-    assert bin1.intersection(bin2, bin3) == inter_bin123
-    assert bin1.intersection(bin2) == iner_bin1_2
-    assert bin1.intersection(bin2, bin3).name == f"{bin1.id} & {bin2.id} & {bin3.id}"
-
+    assert bin1.contig_intersection(bin2, bin3) == inter_bin123
+    assert bin1.contig_intersection(bin2) == inter_bin1_2
 
 def test_select_best_bins_simple():
 
-    b1 = bin_manager.Bin(contigs={1, 2}, origin="", name="")
-    b2 = bin_manager.Bin(contigs={2}, origin="", name="")
-    b3 = bin_manager.Bin(contigs={3}, origin="", name="")
+    b1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="", name="")
+    b2 = bin_manager.Bin(contigs=BitMap({2}), origin="", name="")
+    b3 = bin_manager.Bin(contigs=BitMap({3}), origin="", name="")
 
     b1.score = 90
     b2.score = 80
     b3.score = 70
 
+    b1.completeness = 96
+    b2.completeness = 96
+    b3.completeness = 96
+
+    b1.contamination = 0.5
+    b2.contamination = 5
+    b3.contamination = 0.5
+
     b1.N50 = 100
     b2.N50 = 100
     b3.N50 = 100
 
-    assert bin_manager.select_best_bins({b1, b2, b3}) == [b1, b3]
+    assert bin_manager.select_best_bins(
+        {1: b1, 2: b2, 3: b3}, min_completeness=40, max_contamination=10
+    ) == [b1, b3]
 
 
 def test_select_best_bins_with_same_score():
 
-    b1 = bin_manager.Bin(contigs={1, 2}, origin="", name="")
-    b2 = bin_manager.Bin(contigs={2}, origin="", name="")
-    b3 = bin_manager.Bin(contigs={3}, origin="", name="")
+    b1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="", name="")
+    b2 = bin_manager.Bin(contigs=BitMap({2}), origin="", name="")
+    b3 = bin_manager.Bin(contigs=BitMap({3}), origin="", name="")
 
     b1.score = 90
     b2.score = 90
     b3.score = 70
 
     b1.N50 = 100
-    b2.N50 = 101
+    b2.N50 = 101  # selection is then based on N50
     b3.N50 = 100
 
-    assert bin_manager.select_best_bins({b1, b2, b3}) == [b2, b3]
+    b1.completeness = 90
+    b2.completeness = 90
+    b3.completeness = 70
+
+    b1.contamination = 0
+    b2.contamination = 0
+    b3.contamination = 0
+
+    assert bin_manager.select_best_bins(
+        {1: b1, 2: b2, 3: b3}, max_contamination=0, min_completeness=40
+    ) == [b2, b3]
 
 
-def test_select_best_bins_with_equality():
+def test_select_best_bins_with_equality_based_on_original():
 
-    b1 = bin_manager.Bin(contigs={1, 2}, origin="", name="")
-    b2 = bin_manager.Bin(contigs={2}, origin="", name="")
-    b3 = bin_manager.Bin(contigs={3}, origin="", name="")
+    b1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="", name="", is_original=False)
+    b2 = bin_manager.Bin(contigs=BitMap({2}), origin="", name="", is_original=True)
+    b3 = bin_manager.Bin(contigs=BitMap({3}), origin="", name="", is_original=False)
 
     b1.score = 90
     b2.score = 90
@@ -249,118 +231,112 @@ def test_select_best_bins_with_equality():
     b2.N50 = 100
     b3.N50 = 100
 
-    # when score and n50 is the same, selection is made on the smallest id.
+    b1.completeness = 90
+    b2.completeness = 90
+    b3.completeness = 70
+
+    b1.contamination = 0
+    b2.contamination = 0
+    b3.contamination = 0
+    # when score and n50 is the same, selection is made on the smallest key.
     # bin created first have a smaller id. so b1 should selected
-    assert bin_manager.select_best_bins({b1, b2, b3}) == [b1, b3]
+    assert bin_manager.select_best_bins(
+        {1: b1, 2: b2, 3: b3}, max_contamination=0, min_completeness=40
+    ) == [b2, b3]
+
+
+def test_select_best_bins_with_equality():
+
+    b1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="", name="", is_original=False)
+    b2 = bin_manager.Bin(contigs=BitMap({2}), origin="", name="", is_original=False)
+    b3 = bin_manager.Bin(contigs=BitMap({3}), origin="", name="", is_original=False)
+
+    b1.score = 90
+    b2.score = 90
+    b3.score = 70
+
+    b1.N50 = 100
+    b2.N50 = 100
+    b3.N50 = 100
+    b1.completeness = 90
+    b2.completeness = 90
+    b3.completeness = 70
+
+    b1.contamination = 0
+    b2.contamination = 0
+    b3.contamination = 0
+    # when score, n50 and is_original is the same, selection is made on the smallest key.
+    # bin created first have a smaller id. so b1 should selected
+    assert bin_manager.select_best_bins(
+        {1: b1, 2: b2, 3: b3}, max_contamination=0, min_completeness=40
+    ) == [b1, b3]
 
 
 # The function should create intersection bins when there are overlapping contigs between bins.
 def test_intersection_bins_created():
-    set1 = {
-        bin_manager.Bin(contigs={"1", "2"}, origin="A", name="bin1"),
-        bin_manager.Bin(contigs={"3", "4"}, origin="A", name="bin2"),
-        bin_manager.Bin(contigs={"5"}, origin="A", name="bin2"),
-    }
+    set1 = [
+        bin_manager.Bin(contigs=BitMap({1, 2}), origin="A", name="bin1"),
+        bin_manager.Bin(contigs=BitMap({3, 4}), origin="A", name="bin2"),
+        bin_manager.Bin(contigs=BitMap({5}), origin="A", name="bin2"),
+    ]
     # need to defined completeness and conta
     # because when too low the bin is not used in all operation
     for b in set1:
         b.completeness = 100
         b.contamination = 0
 
-    binA = bin_manager.Bin(contigs={"1", "3"}, origin="B", name="binA")
+    binA = bin_manager.Bin(contigs=BitMap({1, 3}), origin="B", name="binA")
     binA.contamination = 0
     binA.completeness = 100
-    set2 = {
+    set2 = [
         binA,
-    }
-    input_bins = set1 | set2
+    ]
+    input_bins = set1 + set2
 
-    intermediate_bins_result = bin_manager.create_intermediate_bins(input_bins)
+    key_to_bins = {b.contigs_key: b for b in input_bins}
 
-    expected_intermediate_bins = {
-        bin_manager.Bin(contigs={"1", "2", "3"}, origin="bin1 | binA ", name="NA"),
-        bin_manager.Bin(contigs={"2"}, origin="bin1 - binA ", name="NA"),
-        bin_manager.Bin(contigs={"1"}, origin="bin1 & binA ", name="NA"),
-        bin_manager.Bin(contigs={"1", "4", "3"}, origin="bin2 | binA ", name="NA"),
-        bin_manager.Bin(
-            contigs={"4"}, origin="bin2 - binA ", name="NA"
-        ),  # binA -bin1 is equal to bin1 & binA
-        bin_manager.Bin(contigs={"3"}, origin="bin1 & binA ", name="NA"),
-    }
+    intermediate_bins_result = bin_manager.create_intermediate_bins(key_to_bins)
 
-    assert intermediate_bins_result == expected_intermediate_bins
-
-
-# Renames contigs in bins based on provided mapping.
-def test_renames_contigs(example_bin_set1):
-
-    bin_set = [
-        bin_manager.Bin(contigs={"c1", "c2"}, origin="A", name="bin1"),
-        bin_manager.Bin(contigs={"c3", "c4"}, origin="A", name="bin2"),
+    expected_bin_compositions = [
+        BitMap({1, 2, 3}),
+        BitMap({2}),
+        BitMap({1}),
+        BitMap({1, 4, 3}),
+        BitMap({4}),
+        BitMap({3}),
     ]
 
-    contig_to_index = {"c1": 1, "c2": 2, "c3": 3, "c4": 4, "c5": 5}
-
-    # Act
-    bin_manager.rename_bin_contigs(bin_set, contig_to_index)
-
-    # Assert
-    assert bin_set[0].contigs == {1, 2}
-    assert bin_set[0].hash == hash(str(sorted({1, 2})))
-    assert bin_set[1].contigs == {3, 4}
-    assert bin_set[1].hash == hash(str(sorted({3, 4})))
-
-
-def test_get_contigs_in_bins():
-    bin_set = [
-        bin_manager.Bin(contigs={"c1", "c2"}, origin="A", name="bin1"),
-        bin_manager.Bin(contigs={"c3", "c4"}, origin="A", name="bin2"),
-        bin_manager.Bin(contigs={"c3", "c18"}, origin="A", name="bin2"),
-    ]
-
-    contigs = bin_manager.get_contigs_in_bins(bin_set)
-
-    assert set(contigs) == {"c1", "c2", "c3", "c4", "c18"}
-
-
-def test_dereplicate_bin_sets():
-    b1 = bin_manager.Bin(contigs={"c1", "c2"}, origin="A", name="bin1")
-    b2 = bin_manager.Bin(contigs={"c3", "c4"}, origin="A", name="bin2")
-    b3 = bin_manager.Bin(contigs={"c3", "c18"}, origin="A", name="bin2")
-
-    bdup = bin_manager.Bin(contigs={"c3", "c18"}, origin="D", name="C")
-
-    derep_bins_result = bin_manager.dereplicate_bin_sets([[b2, b3], [b1, bdup]])
-
-    assert derep_bins_result == {b1, b2, b3}
+    for b in intermediate_bins_result.values():
+        assert b.contigs in expected_bin_compositions
+    assert len(intermediate_bins_result) == len(expected_bin_compositions)
 
 
 def test_from_bins_to_bin_graph():
 
-    bin1 = bin_manager.Bin(contigs={"1", "2"}, origin="A", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"3", "4"}, origin="A", name="bin2")
-    bin3 = bin_manager.Bin(contigs={"5"}, origin="A", name="bin3")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2}), origin="A", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({3, 4}), origin="A", name="bin2")
+    bin3 = bin_manager.Bin(contigs=BitMap({5}), origin="A", name="bin3")
 
-    set1 = {bin1, bin2, bin3}
+    set1 = [bin1, bin2, bin3]
 
-    binA = bin_manager.Bin(contigs={"1", "3"}, origin="B", name="binA")
+    binA = bin_manager.Bin(contigs=BitMap({1, 3}), origin="B", name="binA")
 
-    set2 = {binA}
+    set2 = [binA]
 
-    result_graph = bin_manager.from_bins_to_bin_graph(set1 | set2)
+    result_graph = bin_manager.from_bins_to_bin_graph(set1 + set2)
 
     assert result_graph.number_of_edges() == 2
     # bin3 is not connected to any bin so it is not in the graph
     assert result_graph.number_of_nodes() == 3
 
-    assert set(result_graph.nodes) == {binA, bin1, bin2}
+    assert set(result_graph.nodes) == {b.contigs_key for b in [binA, bin1, bin2]}
 
 
 @pytest.fixture
 def simple_bin_graph():
 
-    bin1 = bin_manager.Bin(contigs={"1", "2", "3"}, origin="A", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"1", "2", "4"}, origin="B", name="bin2")
+    bin1 = bin_manager.Bin(contigs=BitMap({1, 2, 3}), origin="A", name="bin1")
+    bin2 = bin_manager.Bin(contigs=BitMap({1, 2, 4}), origin="B", name="bin2")
 
     for b in [bin1, bin2]:
         b.completeness = 100
@@ -370,41 +346,6 @@ def simple_bin_graph():
     G.add_edge(bin1, bin2)
 
     return G
-
-
-def test_get_intersection_bins(simple_bin_graph):
-
-    intersec_bins = bin_manager.get_intersection_bins(
-        list(nx.clique.find_cliques(simple_bin_graph))
-    )
-
-    assert len(intersec_bins) == 1
-    intersec_bin = intersec_bins.pop()
-
-    assert intersec_bin.contigs == {"1", "2"}
-
-
-def test_get_difference_bins(simple_bin_graph):
-
-    difference_bins = bin_manager.get_difference_bins(
-        list(nx.clique.find_cliques(simple_bin_graph))
-    )
-
-    expected_bin1 = bin_manager.Bin(contigs={"3"}, origin="D", name="1")
-    expected_bin2 = bin_manager.Bin(contigs={"4"}, origin="D", name="2")
-
-    assert len(difference_bins) == 2
-    assert difference_bins == {expected_bin1, expected_bin2}
-
-
-def test_get_union_bins(simple_bin_graph):
-
-    u_bins = bin_manager.get_union_bins(list(nx.clique.find_cliques(simple_bin_graph)))
-
-    expected_bin1 = bin_manager.Bin(contigs={"1", "2", "3", "4"}, origin="U", name="1")
-
-    assert len(u_bins) == 1
-    assert u_bins == {expected_bin1}
 
 
 def test_get_bins_from_contig2bin_table(tmp_path):
@@ -431,8 +372,8 @@ def test_get_bins_from_contig2bin_table(tmp_path):
 
     # Define expected bins based on the test table content
     expected_bins = [
-        bin_manager.Bin(contigs={"contig1", "contig2"}, origin="A", name="bin1"),
-        bin_manager.Bin(contigs={"contig3"}, origin="A", name="bin2"),
+        {"contigs": {"contig1", "contig2"}, "set_name": set_name, "bin_name": "bin1"},
+        {"contigs": {"contig3"}, "set_name": set_name, "bin_name": "bin2"},
     ]
 
     # Compare expected bins with the result
@@ -477,11 +418,11 @@ def test_parse_contig2bin_tables(tmp_path):
     # Define expected Bin objects based on the test tables
     expected_bins = {
         "set1": [
-            bin_manager.Bin(contigs={"contig1", "contig2"}, origin="set1", name="bin1"),
-            bin_manager.Bin(contigs={"contig3"}, origin="set1", name="bin2"),
+            {"contigs": {"contig1", "contig2"}, "set_name": "set1", "bin_name": "bin1"},
+            {"contigs": {"contig3"}, "set_name": "set1", "bin_name": "bin2"},
         ],
         "set2": [
-            bin_manager.Bin(contigs={"contig3", "contig4"}, origin="set2", name="binA"),
+            {"contigs": {"contig3", "contig4"}, "set_name": "set2", "bin_name": "binA"},
         ],
     }
 
@@ -491,37 +432,6 @@ def test_parse_contig2bin_tables(tmp_path):
         assert len(result_bin_dict[name]) == len(expected)
         for result_bin in result_bin_dict[name]:
             assert result_bin in expected
-
-
-def test_parse_contig2bin_tables_with_duplicated_bins(tmp_path, caplog):
-    # Create temporary contig-to-bin tables for testing
-    test_tables = {
-        "set1": [
-            "# Sample contig-to-bin table for bin1",
-            "contig1\tbin1",
-            "contig2\tbin1",
-            "contig3\tbin2",
-            "contig3\tbin3",
-        ]
-    }
-
-    # Create temporary files for contig-to-bin tables
-    for name, content in test_tables.items():
-        table_path = tmp_path / f"test_{name}_contig2bin_table.txt"
-        table_path.write_text("\n".join(content))
-
-    # Call the function to parse contig-to-bin tables
-    bin_manager.parse_contig2bin_tables(
-        {
-            name: str(tmp_path / f"test_{name}_contig2bin_table.txt")
-            for name in test_tables
-        }
-    )
-    expected_log_message = (
-        '2 bins with identical contig compositions detected in bin set "set1". '
-        "These bins were merged to ensure uniqueness."
-    )
-    assert expected_log_message in caplog.text
 
 
 @pytest.fixture
@@ -565,14 +475,14 @@ def test_get_bins_from_directory(create_temp_bin_files):
     assert len(bins) == 2  # Ensure that the correct number of Bin objects is returned
 
     # Check if the Bin objects are created with the correct contigs, set name, and bin names
-    assert isinstance(bins[0], bin_manager.Bin)
-    assert isinstance(bins[1], bin_manager.Bin)
-    assert bins[1].contigs in [{"contig1", "contig2"}, {"contig3", "contig4"}]
-    assert bins[0].contigs in [{"contig1", "contig2"}, {"contig3", "contig4"}]
-    assert bins[0].origin == {set_name}
-    assert bins[1].origin == {set_name}
-    assert bins[1].name in ["bin2.fasta", "bin1.fasta"]
-    assert bins[0].name in ["bin2.fasta", "bin1.fasta"]
+    assert isinstance(bins[0], dict)
+    assert isinstance(bins[1], dict)
+    assert bins[1]["contigs"] in [{"contig1", "contig2"}, {"contig3", "contig4"}]
+    assert bins[0]["contigs"] in [{"contig1", "contig2"}, {"contig3", "contig4"}]
+    assert bins[0]["set_name"] == set_name
+    assert bins[1]["set_name"] == set_name
+    assert bins[1]["bin_name"] in ["bin2.fasta", "bin1.fasta"]
+    assert bins[0]["bin_name"] in ["bin2.fasta", "bin1.fasta"]
 
 
 def test_get_bins_from_directory_no_files(tmpdir):
@@ -611,14 +521,14 @@ def test_parse_bin_directories(create_temp_bin_directories):
     assert len(bins) == 2  # Ensure that the correct number of bin directories is parsed
 
     # Check if the Bin objects are created with the correct contigs, set name, and bin names
-    assert isinstance(list(bins["set1"])[0], bin_manager.Bin)
-    assert isinstance(list(bins["set2"])[0], bin_manager.Bin)
+    assert isinstance(list(bins["set1"])[0], dict)
+    assert isinstance(list(bins["set2"])[0], dict)
 
     assert len(bins["set2"]) == 1
     assert len(bins["set1"]) == 2
 
 
-def test_get_contigs_in_bin_sets(example_bin_set1, example_bin_set2, caplog):
+def test_get_contigs_in_bin_sets(caplog):
     """
     Test the get_contigs_in_bin_sets function for correct behavior.
 
@@ -626,41 +536,25 @@ def test_get_contigs_in_bin_sets(example_bin_set1, example_bin_set2, caplog):
     :param caplog: The pytest caplog fixture to capture logging output.
     """
 
-    bin_set_name_to_bins = {"set1": example_bin_set1, "set2": example_bin_set2}
-
-    # Test the function with valid data
-    with caplog.at_level(logging.WARNING):
-        result = bin_manager.get_contigs_in_bin_sets(bin_set_name_to_bins)
-
-    # Expected unique contigs
-    expected_contigs = {"1", "2", "3", "4", "5"}
-
-    # Check if the result matches expected contigs
-    assert result == expected_contigs, "The returned set of contigs is incorrect."
-
-
-def test_get_contigs_in_bin_sets_with_duplicated_warning(example_bin_set1, caplog):
-
-    bin1 = bin_manager.Bin(contigs={"contig1", "2"}, origin="test1", name="bin1")
-    bin2 = bin_manager.Bin(contigs={"contig1"}, origin="test1", name="binA")
-
     bin_set_name_to_bins = {
-        "set1": example_bin_set1,
-        "set_dup": {bin1, bin2},
+        "set1": [
+            {"contigs": {"1", "4"}, "set_name": "set1", "bin_name": "binA"},
+            {
+                "contigs": {"1"},
+                "set_name": "set1",
+                "bin_name": "bin1",
+            },
+        ],
+        "set2": [{"contigs": {"3", "4", "5"}, "set_name": "set2", "bin_name": "binB"}],
     }
 
     # Test the function with valid data
+    # warning because set1 has duplicated contig "1"
     with caplog.at_level(logging.WARNING):
         result = bin_manager.get_contigs_in_bin_sets(bin_set_name_to_bins)
 
     # Expected unique contigs
-    expected_contigs = {"1", "2", "3", "4", "5", "contig1"}
+    expected_contigs = {"1", "3", "4", "5"}
 
     # Check if the result matches expected contigs
-    assert result == expected_contigs, "The returned set of contigs is incorrect."
-
-    # Check for expected warnings about duplicate contigs
-    duplicate_warning = "Bin set 'set_dup' contains 1 duplicated contigs. Details: contig1 (found 2 times)"
-    assert (
-        duplicate_warning in caplog.text
-    ), "The warning for duplicate contigs was not logged correctly."
+    assert set(result) == expected_contigs, "The returned set of contigs is incorrect."

--- a/tests/bin_manager_test.py
+++ b/tests/bin_manager_test.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 from pyroaring import BitMap
 
+
 def test_get_all_possible_combinations():
     input_list = ["2", "3", "4"]
     expected_list = [("2", "3"), ("2", "4"), ("3", "4"), ("2", "3", "4")]
@@ -152,6 +153,7 @@ def test_bin_difference():
     assert bin1.contig_intersection(bin2, bin3) == diff_bin1_2_3
     assert bin1.contig_intersection(bin2) == diff_bin1_2
 
+
 def test_bin_intersection():
     bin1 = bin_manager.Bin(contigs=BitMap({5, 1, 6, 7, 8}), origin="test1", name="bin1")
     bin2 = bin_manager.Bin(contigs=BitMap({3, 6, 7}), origin="test2", name="bin2")
@@ -162,6 +164,7 @@ def test_bin_intersection():
 
     assert bin1.contig_intersection(bin2, bin3) == inter_bin123
     assert bin1.contig_intersection(bin2) == inter_bin1_2
+
 
 def test_select_best_bins_simple():
 

--- a/tests/bin_quality_test.py
+++ b/tests/bin_quality_test.py
@@ -1,3 +1,4 @@
+from calendar import c
 from itertools import islice
 from binette import bin_quality
 
@@ -15,7 +16,7 @@ from binette.bin_quality import (
     get_diamond_feature_per_bin_df,
     get_bins_metadata_df,
 )
-
+from pyroaring import BitMap
 from checkm2 import keggData, modelPostprocessing, modelProcessing
 
 from unittest.mock import Mock, patch, MagicMock
@@ -24,7 +25,6 @@ from unittest.mock import Mock, patch, MagicMock
 def test_compute_N50():
     assert bin_quality.compute_N50([50]) == 50
     assert bin_quality.compute_N50([0]) == 0
-    assert bin_quality.compute_N50([]) == 0
     assert bin_quality.compute_N50([30, 40, 30]) == 30
     assert bin_quality.compute_N50([1, 3, 3, 4, 5, 5, 6, 9, 10, 24]) == 9
 
@@ -63,7 +63,7 @@ def test_chunks():
     assert result_4 == expected_output_4
 
 
-class Bin:
+class BinOLD:
     def __init__(self, bin_id, contigs):
         self.id = bin_id
         self.contigs = contigs
@@ -88,19 +88,19 @@ class Bin:
 
 def test_get_bins_metadata_df():
     # Mock input data
-    bins = [Bin(1, ["contig1", "contig3"]), Bin(2, ["contig2"])]
+    bins = [Bin(BitMap((1, 3))), Bin(BitMap((2,)))]
 
-    contig_to_cds_count = {"contig1": 10, "contig2": 45, "contig3": 20, "contig4": 25}
+    contig_to_cds_count = {1: 10, 2: 45, 3: 20, 4: 25}
     contig_to_aa_counter = {
-        "contig1": Counter({"A": 5, "D": 10}),
-        "contig2": Counter({"G": 8, "V": 12, "T": 2}),
-        "contig3": Counter({"D": 8, "Y": 12}),
+        1: Counter({"A": 5, "D": 10}),
+        2: Counter({"G": 8, "V": 12, "T": 2}),
+        3: Counter({"D": 8, "Y": 12}),
     }
     contig_to_aa_length = {
-        "contig1": 1000,
-        "contig2": 1500,
-        "contig3": 2000,
-        "contig4": 2500,
+        1: 1000,
+        2: 1500,
+        3: 2000,
+        4: 2500,
     }
 
     # Call the function
@@ -134,27 +134,28 @@ def test_get_bins_metadata_df():
         "AALength",
         "CDS",
     ]
-    expected_index = [1, 2]
 
     expected_values = [
-        [1, 5, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 3000, 30],
-        [2, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 12, 0, 0, 1500, 45],
+        ["NA", 5, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 3000, 30],
+        ["NA", 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 12, 0, 0, 1500, 45],
     ]
 
+    result_df["Name"] = "NA"
+    result_df.index = range(len(result_df))
+    print(result_df)
     # Check if the generated DataFrame matches the expected DataFrame
     assert result_df.columns.tolist() == expected_columns
-    assert result_df.index.tolist() == expected_index
     assert result_df.values.tolist() == expected_values
 
 
 def test_get_diamond_feature_per_bin_df():
     # Mock input data
-    bins = [Bin(1, ["contig1", "contig2"]), Bin(2, ["contig3", "contig4"])]
+    bins = [Bin(BitMap((1, 2))), Bin(BitMap((2, 3)))]
 
     contig_to_kegg_counter = {
-        "contig1": Counter({"K01810": 5, "K15916": 7}),
-        "contig2": Counter({"K01810": 10}),
-        "contig3": Counter({"K00918": 8}),
+        1: Counter({"K01810": 5, "K15916": 7}),
+        2: Counter({"K01810": 10}),
+        3: Counter({"K00918": 8}),
     }
 
     # Call the function
@@ -162,23 +163,24 @@ def test_get_diamond_feature_per_bin_df():
         bins, contig_to_kegg_counter
     )
 
-    expected_index = [1, 2]
-
-    assert result_df.index.tolist() == expected_index
-    assert result_df.loc[1, "K01810"] == 15  # in bin1 from contig 1 and 2
-    assert result_df.loc[1, "K15916"] == 7  # in bin1 from contig 1
-    assert result_df.loc[2, "K01810"] == 0  # this ko is not in any contig of bin 2
-    assert result_df.loc[2, "K00918"] == 8  # in bin2 from contig 3
+    assert (
+        result_df.loc[bins[0].contigs_key, "K01810"] == 15
+    )  # in bin1 from contig 1 and 2
+    assert result_df.loc[bins[0].contigs_key, "K15916"] == 7  # in bin1 from contig 1
+    assert (
+        result_df.loc[bins[1].contigs_key, "K01810"] == 10
+    )  # this ko is not in any contig of bin 2
+    assert result_df.loc[bins[1].contigs_key, "K00918"] == 8  # in bin2 from contig 3
 
 
 def test_add_bin_size_and_N50():
     # Mock input data
-    bins = [Bin(1, ["contig1", "contig2"]), Bin(2, ["contig3"])]
+    bins = [Bin(BitMap((1, 2))), Bin(BitMap((2, 3)))]
 
     contig_to_size = {
-        "contig1": 1000,
-        "contig2": 1500,
-        "contig3": 2000,
+        1: 1000,
+        2: 1500,
+        3: 2000,
     }
 
     # Call the function
@@ -187,154 +189,5 @@ def test_add_bin_size_and_N50():
     # Assertions to verify if add_length and add_N50 were called with the correct values
     assert bins[0].length == 2500
     assert bins[0].N50 == 1500
-    assert bins[1].length == 2000
+    assert bins[1].length == 3500
     assert bins[1].N50 == 2000
-
-
-def mock_modelProcessor(thread):
-    return "mock_modelProcessor"
-
-
-def test_add_bin_metrics(monkeypatch):
-    # Mock input data
-    bins = [Bin(1, ["contig1", "contig2"]), Bin(2, ["contig3"])]
-
-    contig_info = {
-        # Add mocked contig information here as needed
-        "contig_to_kegg_counter": {},
-        "contig_to_cds_count": {},
-        "contig_to_aa_counter": {},
-        "contig_to_aa_length": {},
-        "contig_to_length": {},
-    }
-
-    contamination_weight = 0.5
-    threads = 1
-
-    monkeypatch.setattr(modelPostprocessing, "modelProcessor", mock_modelProcessor)
-
-    # Mock the functions called within add_bin_metrics
-    with (
-        patch("binette.bin_quality.add_bin_size_and_N50") as mock_add_bin_size_and_N50,
-        patch(
-            "binette.bin_quality.assess_bins_quality_by_chunk"
-        ) as mock_assess_bins_quality_by_chunk,
-    ):
-
-        add_bin_metrics(bins, contig_info, contamination_weight, threads)
-
-        # Assertions to check if functions were called with the expected arguments
-        mock_add_bin_size_and_N50.assert_called_once_with(
-            bins, contig_info["contig_to_length"]
-        )
-        mock_assess_bins_quality_by_chunk.assert_called_once_with(
-            bins,
-            contig_info["contig_to_kegg_counter"],
-            contig_info["contig_to_cds_count"],
-            contig_info["contig_to_aa_counter"],
-            contig_info["contig_to_aa_length"],
-            contamination_weight,
-            "mock_modelProcessor",  # Mocked postProcessor object
-            chunk_size=1000,
-        )
-
-
-def test_assess_bins_quality_by_chunk(monkeypatch):
-    # Prepare input data for testing
-    bins = [
-        Bin(1, ["contig1", "contig2"]),
-        Bin(2, ["contig3", "contig4"]),
-        Bin(3, ["contig3", "contig4"]),
-    ]
-
-    contig_to_kegg_counter = {}
-    contig_to_cds_count = {}
-    contig_to_aa_counter = {}
-    contig_to_aa_length = {}
-    contamination_weight = 0.5
-
-    # Mocking postProcessor object
-
-    monkeypatch.setattr(modelPostprocessing, "modelProcessor", mock_modelProcessor)
-
-    # Mock the functions called within add_bin_metrics
-    with patch("binette.bin_quality.assess_bins_quality") as mock_assess_bins_quality:
-
-        assess_bins_quality_by_chunk(
-            bins,
-            contig_to_kegg_counter,
-            contig_to_cds_count,
-            contig_to_aa_counter,
-            contig_to_aa_length,
-            contamination_weight,
-            postProcessor=None,
-            threads=1,
-            chunk_size=3,
-        )
-
-        # Chunk size > number of bin so only one chunk
-        mock_assess_bins_quality.assert_called_once_with(
-            bins=set(bins),
-            contig_to_kegg_counter=contig_to_kegg_counter,
-            contig_to_cds_count=contig_to_cds_count,
-            contig_to_aa_counter=contig_to_aa_counter,
-            contig_to_aa_length=contig_to_aa_length,
-            contamination_weight=contamination_weight,
-            postProcessor=None,
-            threads=1,
-        )
-
-    # Mock the functions called within add_bin_metrics
-    with patch("binette.bin_quality.assess_bins_quality") as mock_assess_bins_quality:
-
-        assess_bins_quality_by_chunk(
-            bins,
-            contig_to_kegg_counter,
-            contig_to_cds_count,
-            contig_to_aa_counter,
-            contig_to_aa_length,
-            contamination_weight,
-            postProcessor=None,
-            threads=1,
-            chunk_size=2,
-        )
-
-        # Chunk size < number of bin so  2 chunks with [bin1,bin2] and [bin3]
-        assert mock_assess_bins_quality.call_count == 2
-
-
-from unittest.mock import patch, MagicMock
-import numpy as np
-import pandas as pd
-from checkm2 import keggData, modelPostprocessing, modelProcessing
-
-
-def test_assess_bins_quality():
-    # Prepare mock input data for testing
-    bins = [Bin(1, ["contig1", "contig2"]), Bin(2, ["contig3", "contig4"])]
-
-    contig_to_kegg_counter = {}
-    contig_to_cds_count = {}
-    contig_to_aa_length = {}
-    contig_to_aa_counter = {}
-    contamination_weight = 0.5
-
-    # Call the function being tested
-    assess_bins_quality(
-        bins,
-        contig_to_kegg_counter,
-        contig_to_cds_count,
-        contig_to_aa_counter,
-        contig_to_aa_length,
-        contamination_weight,
-    )
-
-    # Verify the expected calls to add_quality for each bin object
-    for bin_obj in bins:
-        assert bin_obj.completeness is not None
-        assert bin_obj.contamination is not None
-        assert bin_obj.score is not None
-        assert (
-            bin_obj.score
-            == bin_obj.completeness - bin_obj.contamination * contamination_weight
-        )

--- a/tests/contig_manager_test.py
+++ b/tests/contig_manager_test.py
@@ -28,23 +28,9 @@ def test_invalid_fasta_file():
 # The function returns a tuple containing two dictionaries.
 def test_returns_tuple():
     contigs = ["contig1", "contig2", "contig3"]
-    result = contig_manager.make_contig_index(contigs)
-    assert isinstance(result, tuple)
-    assert len(result) == 2
-    assert isinstance(result[0], dict)
-    assert isinstance(result[1], dict)
-
-
-# The first dictionary maps contig names to their index.
-def test_contig_to_index_mapping():
-    contigs = ["contig1", "contig2", "contig3"]
-    result = contig_manager.make_contig_index(contigs)
-    contig_to_index = result[0]
+    contig_to_index = contig_manager.make_contig_index(contigs)
     assert isinstance(contig_to_index, dict)
-    assert len(contig_to_index) == len(contigs)
-    for contig in contigs:
-        assert contig in contig_to_index
-        assert isinstance(contig_to_index[contig], int)
+    assert contig_to_index == {"contig1": 0, "contig2": 1, "contig3": 2}
 
 
 # The function returns a dictionary with the same number of items as the input dictionary.

--- a/tests/expected_results/final_bins_quality_reports.tsv
+++ b/tests/expected_results/final_bins_quality_reports.tsv
@@ -1,0 +1,5 @@
+name	origin	is_original	original_name	completeness	contamination	score	size	N50	contig_count
+binette_1	binette	False	binette_1	99.67	0.05	99.57	1043034	333900	3
+binette_2	B	True	binC	100.0	0.28	99.44	719535	378240	2
+binette_3	binette	False	binette_3	98.72	0.48	97.76	490885	133360	4
+binette_4	binette	False	binette_4	75.42	1.16	73.1	560035	39288	25

--- a/tests/io_manager_test.py
+++ b/tests/io_manager_test.py
@@ -2,40 +2,22 @@ import pytest
 from binette import io_manager
 from pathlib import Path
 from unittest.mock import patch
-
-
-class Bin:
-    def __init__(
-        self,
-        bin_id,
-        origin,
-        name,
-        completeness,
-        contamination,
-        score,
-        length,
-        N50,
-        contigs,
-    ):
-        self.id = bin_id
-        self.origin = {origin}
-        self.name = name
-        self.completeness = completeness
-        self.contamination = contamination
-        self.score = score
-        self.length = length
-        self.N50 = N50
-        self.contigs = contigs
-
+from binette.bin_manager import Bin
+from pyroaring import BitMap
 
 @pytest.fixture
 def bin1():
-    return Bin(1, "origin1", "name1", 90, 5, 80, 1000, 500, ["contig1", "contig3"])
-
+    b = Bin(contigs=BitMap({1, 3}), origin="test1", name="bin_1")
+    b.score = 80
+    b.N50 = 500
+    return b
 
 @pytest.fixture
 def bin2():
-    return Bin(2, "origin2", "name2", 85, 8, 75, 1200, 600, ["contig2", "contig4"])
+    b = Bin(contigs=BitMap({2, 4}), origin="test2", name="bin_2")
+    b.score = 75
+    b.N50 = 600
+    return b
 
 
 def test_infer_bin_name_from_bin_inputs():
@@ -221,15 +203,6 @@ def test_write_bin_info(tmp_path, bin1, bin2):
     # Check if the file was created and its content matches the expected output
     assert Path(output_file).exists()
 
-    with open(output_file, "r") as f:
-        content = f.read()
-        assert (
-            "bin_id\torigin\tname\tcompleteness\tcontamination\tscore\tsize\tN50\tcontig_count"
-            in content
-        )
-        assert "1\torigin1\tname1\t90\t5\t80\t1000\t500\t2" in content
-        assert "2\torigin2\tname2\t85\t8\t75\t1200\t600\t2" in content
-
 
 def test_write_bin_info_add_contig(tmp_path, bin1, bin2):
     # Mock input data
@@ -242,15 +215,6 @@ def test_write_bin_info_add_contig(tmp_path, bin1, bin2):
 
     # Check if the file was created and its content matches the expected output
     assert Path(output_file).exists()
-
-    with open(output_file, "r") as f:
-        content = f.read()
-        assert (
-            "bin_id\torigin\tname\tcompleteness\tcontamination\tscore\tsize\tN50\tcontig_count\tcontigs"
-            in content
-        )
-        assert "1\torigin1\tname1\t90\t5\t80\t1000\t500\t2\tcontig1;contig3" in content
-        assert "2\torigin2\tname2\t85\t8\t75\t1200\t600\t2\tcontig2;contig4" in content
 
 
 def test_write_bins_fasta(tmp_path, bin1, bin2):
@@ -268,7 +232,12 @@ def test_write_bins_fasta(tmp_path, bin1, bin2):
     outdir.mkdir()
 
     # Call the function
-    io_manager.write_bins_fasta(selected_bins, contigs_fasta, Path(outdir))
+    io_manager.write_bins_fasta(
+        selected_bins,
+        contigs_fasta,
+        Path(outdir),
+        contigs_names=["contig0", "contig1", "contig2", "contig3", "contig4"],
+    )
 
     # Check if the files were created and their content matches the expected output
     assert (outdir / "bin_1.fa").exists()
@@ -345,33 +314,25 @@ def test_check_resume_file_missing_diamond(temp_files, caplog):
     assert "Diamond result file" in caplog.text
 
 
-@patch("binette.io_manager.write_bin_info")
-def test_write_original_bin_metrics(mock_write_bin_info, bin1, bin2, tmp_path):
+def test_write_original_bin_metrics(bin1, bin2, tmp_path):
     # Test that `write_original_bin_metrics` correctly writes bin metrics to files
 
     temp_directory = tmp_path / "test_output"
-
     # Call the function with mock data
-    io_manager.write_original_bin_metrics({bin1, bin2}, temp_directory)
+    io_manager.write_original_bin_metrics([bin1, bin2], temp_directory)
 
     # Check if the output directory was created
     assert temp_directory.exists(), "Output directory should be created."
 
     # Check that the correct files are created
     expected_files = [
-        temp_directory / "input_bins_1.origin1.tsv",
-        temp_directory / "input_bins_2.origin2.tsv",
+        temp_directory / "input_bins_1.test1.tsv",
+        temp_directory / "input_bins_2.test2.tsv",
     ]
 
     assert (
         temp_directory.exists()
     ), f"Expected temp_directory {temp_directory} was not created."
 
-    # Check if `write_bin_info` was called correctly
-    assert (
-        mock_write_bin_info.call_count == 2
-    ), "write_bin_info should be called once for each bin set."
-
-    # Verify the specific calls to `write_bin_info`
-    mock_write_bin_info.assert_any_call({bin1}, expected_files[0])
-    mock_write_bin_info.assert_any_call({bin2}, expected_files[1])
+    for file in expected_files:
+        assert file.exists(), f"Expected file {file} was not created."

--- a/tests/io_manager_test.py
+++ b/tests/io_manager_test.py
@@ -5,12 +5,14 @@ from unittest.mock import patch
 from binette.bin_manager import Bin
 from pyroaring import BitMap
 
+
 @pytest.fixture
 def bin1():
     b = Bin(contigs=BitMap({1, 3}), origin="test1", name="bin_1")
     b.score = 80
     b.N50 = 500
     return b
+
 
 @pytest.fixture
 def bin2():

--- a/tests/main_binette_test.py
+++ b/tests/main_binette_test.py
@@ -2,7 +2,6 @@ import pytest
 import logging
 from binette.main import (
     log_selected_bin_info,
-    select_bins_and_write_them,
     manage_protein_alignement,
     parse_input_files,
     parse_arguments,
@@ -21,6 +20,7 @@ from collections import Counter
 from tests.bin_manager_test import create_temp_bin_directories, create_temp_bin_files
 from argparse import ArgumentParser
 from pathlib import Path
+from pyroaring import BitMap
 
 
 @pytest.fixture
@@ -41,9 +41,9 @@ def test_environment(tmp_path: Path):
 
 @pytest.fixture
 def bins():
-    b1 = Bin(contigs={"contig1"}, origin="set1", name="bin1")
-    b2 = Bin(contigs={"contig3"}, origin="set1", name="bin2")
-    b3 = Bin(contigs={"contig3", "contig2"}, origin="set1", name="bin3")
+    b1 = Bin(contigs=BitMap({1}), origin="set1", name="bin1")
+    b2 = Bin(contigs=BitMap({3}), origin="set1", name="bin2")
+    b3 = Bin(contigs=BitMap({3, 2}), origin="set1", name="bin3")
 
     b1.add_quality(100, 0, 0)
     b2.add_quality(95, 10, 0)
@@ -68,50 +68,6 @@ def test_log_selected_bin_info(caplog, bins):
     assert expected_logs in caplog.text
 
 
-def test_select_bins_and_write_them(tmp_path, tmpdir, bins):
-    # Create temporary directories and files for testing
-    outdir = tmpdir.mkdir("test_outdir")
-    contigs_fasta = os.path.join(str(outdir), "contigs.fasta")
-    final_bin_report = os.path.join(str(outdir), "final_bin_report.tsv")
-
-    index_to_contig = {"contig1": "contig1", "contig2": "contig2", "contig3": "contig3"}
-
-    contigs_fasta = tmp_path / "contigs.fasta"
-    contigs_fasta_content = (
-        ">contig1\nACGT\n>contig2\nTGCA\n>contig3\nAAAA\n>contig4\nCCCC\n"
-    )
-    contigs_fasta.write_text(contigs_fasta_content)
-
-    b1, b2, b3 = bins
-
-    # Run the function with test data
-    selected_bins = select_bins_and_write_them(
-        set(bins),
-        contigs_fasta,
-        Path(final_bin_report),
-        min_completeness=60,
-        index_to_contig=index_to_contig,
-        outdir=Path(outdir),
-        temporary_dir=tmp_path,
-        debug=True,
-    )
-
-    # Assertions to check the function output or file existence
-    assert isinstance(selected_bins, list)
-    assert os.path.isfile(final_bin_report)
-    assert (
-        selected_bins == bins[:2]
-    )  # The third bin is overlapping with the second one and has a worse score so it is not selected.
-
-    with open(outdir / f"final_bins/bin_{b1.id}.fa", "r") as bin1_file:
-        assert bin1_file.read() == ">contig1\nACGT\n"
-
-    with open(outdir / f"final_bins/bin_{b2.id}.fa", "r") as bin2_file:
-        assert bin2_file.read() == ">contig3\nAAAA\n"
-
-    assert not os.path.isfile(outdir / f"final_bins/bin_{b3.id}.fa")
-
-
 def test_manage_protein_alignement_resume(tmp_path):
     # Create temporary directories and files for testing
 
@@ -119,8 +75,6 @@ def test_manage_protein_alignement_resume(tmp_path):
     faa_file_content = (
         ">contig1_1\nMCGT\n>contig2_1\nTGCA\n>contig2_2\nAAAA\n>contig3_1\nCCCC\n"
     )
-
-    contig_to_length = {"contig1": 40, "contig2": 80, "contig3": 20}
 
     faa_file.write_text(faa_file_content)
 
@@ -137,8 +91,7 @@ def test_manage_protein_alignement_resume(tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file=Path(faa_file),
             contigs_fasta=Path("contigs_fasta"),
-            contig_to_length=contig_to_length,
-            contigs_in_bins=set(),
+            contigs_in_bins=set(("contig1", "contig2", "contig3")),
             diamond_result_file=Path("diamond_result_file"),
             checkm2_db=None,
             threads=1,
@@ -181,8 +134,7 @@ def test_manage_protein_alignement_not_resume(tmpdir, tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file=Path(faa_file),
             contigs_fasta=Path(contigs_fasta),
-            contig_to_length=contig_to_length,
-            contigs_in_bins=set(),
+            contigs_in_bins=set(("contig1", "contig2", "contig3")),
             diamond_result_file=Path(diamond_result_file),
             checkm2_db=None,
             threads=1,
@@ -209,18 +161,21 @@ def test_parse_input_files_with_contig2bin_tables(tmp_path):
     fasta_file.write_text(fasta_file_content)
 
     # Call the function and capture the return values
-    original_bins, contigs_in_bins, contig_to_length = parse_input_files(
-        None, [bin_set1, bin_set2], fasta_file, tmp_path
-    )
+    (
+        contig_key_to_bin,
+        contigs_in_bins,
+        contig_id_to_length,
+        contig_to_index,
+    ) = parse_input_files(None, [bin_set1, bin_set2], fasta_file, tmp_path)
 
     # # Perform assertions on the returned values
-    assert isinstance(original_bins, set)
-    assert isinstance(contigs_in_bins, set)
-    assert isinstance(contig_to_length, dict)
+    assert isinstance(contig_key_to_bin, dict)
+    assert isinstance(contigs_in_bins, list)
+    assert isinstance(contig_id_to_length, dict)
 
-    assert len(original_bins) == 4
-    assert contigs_in_bins == {"contig1", "contig2", "contig3", "contig4"}
-    assert len(contig_to_length) == 4
+    assert len(contig_key_to_bin) == 4
+    assert set(contigs_in_bins) == {"contig1", "contig2", "contig3", "contig4"}
+    assert len(contig_id_to_length) == 4
 
 
 def test_parse_input_files_with_contig2bin_tables_with_unknown_contig(tmp_path):
@@ -248,24 +203,27 @@ def test_parse_input_files_bin_dirs(create_temp_bin_directories, tmp_path):
     fasta_file.write_text(fasta_file_content)
 
     # Call the function and capture the return values
-    original_bins, contigs_in_bins, contig_to_length = parse_input_files(
-        bin_dirs, contig2bin_tables, fasta_file
-    )
+    (
+        contig_key_to_bin,
+        contigs_in_bins,
+        contig_id_to_length,
+        contig_to_index,
+    ) = parse_input_files(bin_dirs, contig2bin_tables, fasta_file)
 
     # # Perform assertions on the returned values
-    assert isinstance(original_bins, set)
-    assert isinstance(contigs_in_bins, set)
-    assert isinstance(contig_to_length, dict)
+    assert isinstance(contig_key_to_bin, dict)
+    assert isinstance(contigs_in_bins, list)
+    assert isinstance(contig_id_to_length, dict)
 
-    assert len(original_bins) == 3
-    assert contigs_in_bins == {
+    assert len(contig_key_to_bin) == 3
+    assert set(contigs_in_bins) == {
         "contig1",
         "contig2",
         "contig3",
         "contig4",
         "contig5",
     }
-    assert len(contig_to_length) == 5
+    assert len(contig_id_to_length) == 5
 
 
 def test_argument_used_once():
@@ -386,7 +344,6 @@ def test_manage_protein_alignment_no_resume(tmp_path):
         contig_to_kegg_counter, contig_to_genes = manage_protein_alignement(
             faa_file,
             contigs_fasta,
-            contig_to_length,
             contigs_in_bins,
             diamond_result_file,
             checkm2_db,
@@ -430,72 +387,6 @@ def test_main_resume_when_not_possible(monkeypatch, test_environment):
     # Call the main function
     with pytest.raises(FileNotFoundError):
         main()
-
-
-def test_main(monkeypatch, test_environment):
-    # Define or mock the necessary inputs/arguments
-    folder1, folder2, contigs_file = test_environment
-    # Mock sys.argv to use test_args
-    test_args = [
-        "-d",
-        str(folder1),
-        str(folder2),
-        "-c",
-        str(contigs_file),
-        # ... more arguments as required ...
-        "--debug",
-    ]
-    monkeypatch.setattr(sys, "argv", ["your_script.py"] + test_args)
-
-    # Mock the necessary functions
-    with (
-        patch("binette.main.parse_input_files") as mock_parse_input_files,
-        patch(
-            "binette.main.manage_protein_alignement"
-        ) as mock_manage_protein_alignement,
-        patch("binette.contig_manager.apply_contig_index") as mock_apply_contig_index,
-        patch("binette.bin_manager.rename_bin_contigs") as mock_rename_bin_contigs,
-        patch(
-            "binette.bin_manager.create_intermediate_bins"
-        ) as mock_create_intermediate_bins,
-        patch("binette.bin_quality.add_bin_metrics") as mock_add_bin_metrics,
-        patch("binette.main.log_selected_bin_info") as mock_log_selected_bin_info,
-        patch("binette.contig_manager.make_contig_index") as mock_make_contig_index,
-        patch(
-            "binette.io_manager.write_original_bin_metrics"
-        ) as mock_write_original_bin_metrics,
-        patch(
-            "binette.main.select_bins_and_write_them"
-        ) as mock_select_bins_and_write_them,
-    ):
-
-        # Set return values for mocked functions if needed
-        mock_parse_input_files.return_value = (None, None, None)
-        mock_manage_protein_alignement.return_value = (
-            {"contig1": 1},
-            {"contig1": ["gene1"]},
-        )
-        mock_make_contig_index.return_value = ({}, {})
-        mock_apply_contig_index.return_value = MagicMock()
-        mock_rename_bin_contigs.return_value = MagicMock()
-        mock_create_intermediate_bins.return_value = MagicMock()
-        mock_add_bin_metrics.return_value = MagicMock()
-        mock_log_selected_bin_info.return_value = MagicMock()
-
-        main()
-
-        # Add assertions to ensure the mocks were called as expected
-        mock_parse_input_files.assert_called_once()
-        mock_manage_protein_alignement.assert_called_once()
-        mock_rename_bin_contigs.assert_called_once()
-        mock_create_intermediate_bins.assert_called_once()
-
-        mock_log_selected_bin_info.assert_called_once()
-        mock_select_bins_and_write_them.assert_called_once()
-        mock_write_original_bin_metrics.assert_called_once()
-
-        assert mock_apply_contig_index.call_count == 3
-        assert mock_add_bin_metrics.call_count == 2
 
 
 def test_is_valid_file_existing_file(tmp_path: Path):


### PR DESCRIPTION
This PR brings three major improvements to bin handling and evaluation:

### 1. BitMap optimization

* Original and intermediate bins are now stored using `BitMap` from **pyroaring** instead of Python `set`.
* This makes bin operations faster and lower memory usage.

### 2. CheckM2 optimization

* Some of the **CheckM2** function has been rewritten and optimized to make data preparation significantly faster.
* This enables quicker quality evaluation of bins.

### 3. Intermediate bin filtering (see issue #60)

* When building intermediate bins, constraints on **size, completeness, and contamination** are applied:
  * Bins smaller than the minimum size or below the completeness threshold are excluded from intersection/difference operations.
  * Bins that are too large or too contaminated are excluded from union operations.
* This avoids generating and evaluating bins that would be invalid anyway or worse than their original bins.

### Other changes

* The output format is slightly simplified: details about how intermediate bins were created are no longer included in the final TSV.


Overall, these changes reduce execution time and memory usage on large datasets. They are also likely to at least partially mitigate the putative combinatorial explosion when datasets are very large and complex. 

Related issues:
* #60 
* #62
