### PR TITLE
Add prefix to final bin name

### DIFF
--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -415,9 +415,16 @@ def select_best_bins(
     bins_dict: dict[bytes, Bin],
     min_completeness: float,
     max_contamination: float,
+    prefix: str = "binette",
 ) -> list[Bin]:
     """
     Select the best non-overlapping bins based on score, N50, and ID.
+
+    :param bins_dict: Mapping from contig_key -> Bin.
+    :param min_completeness: Minimum completeness threshold for a bin to be considered.
+    :param max_contamination: Maximum contamination threshold for a bin to be considered.
+    :param prefix: Prefix to use for naming selected bins.
+
     """
     logging.info("Selecting best bins...")
 
@@ -471,14 +478,12 @@ def select_best_bins(
 
     logging.info(f"Selected {len(selected_bins)} bins")
 
-    # TODO use with a prefix from an optional argument of cli
-    prefix = "binette"
     for i, selected_bin in enumerate(selected_bins, start=1):
         if not selected_bin.origin:
             selected_bin.origin = {"binette"}
         if selected_bin.name is not None:
             selected_bin.original_name = selected_bin.name
-        selected_bin.name = f"{prefix}_{i}"
+        selected_bin.name = f"{prefix}_bin{i}"
     return selected_bins
 
 

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 import logging
-from operator import length_hint
-from typing import Iterable, List, Dict, Tuple, Set
-import csv
+from typing import Iterable, List, Dict, Tuple
+import pandas as pd
 
 from binette.bin_manager import Bin
 
@@ -123,7 +122,8 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
     :param add_contigs: Flag indicating whether to include contig information.
     """
 
-    header = [
+    # Define columns for the DataFrame
+    columns = [
         "name",
         "origin",
         "is_original",
@@ -136,37 +136,37 @@ def write_bin_info(bins: Iterable[Bin], output: Path, add_contigs: bool = False)
         "contig_count",
     ]
     if add_contigs:
-        header.append("contigs")
+        columns.append("contigs")
 
-    bin_infos = []
+    # Create a list of dictionaries to build the DataFrame
+    data = []
     for bin_obj in sorted(
         bins, key=lambda x: (-x.score, -x.N50, -x.is_original, x.contigs_key)
     ):
         original_name = bin_obj.original_name if bin_obj.original_name else bin_obj.name
         origins = bin_obj.origin if bin_obj.is_original else {"binette"}
-        bin_info = [
-            bin_obj.name,
-            ";".join(origins),
-            bin_obj.is_original,
-            original_name,
-            bin_obj.completeness,
-            bin_obj.contamination,
-            round(bin_obj.score, 2),
-            bin_obj.length,
-            bin_obj.N50,
-            len(bin_obj.contigs),
-        ]
+
+        bin_info = {
+            "name": bin_obj.name,
+            "origin": ";".join(origins),
+            "is_original": bin_obj.is_original,
+            "original_name": original_name,
+            "completeness": bin_obj.completeness,
+            "contamination": bin_obj.contamination,
+            "score": round(bin_obj.score, 2),
+            "size": bin_obj.length,
+            "N50": bin_obj.N50,
+            "contig_count": len(bin_obj.contigs),
+        }
+
         if add_contigs:
-            bin_info.append(
-                ";".join(str(c) for c in bin_obj.contigs) if add_contigs else ""
-            )
+            bin_info["contigs"] = ";".join(str(c) for c in bin_obj.contigs)
 
-        bin_infos.append(bin_info)
+        data.append(bin_info)
 
-    with open(output, "w", newline="") as fl:
-        writer = csv.writer(fl, delimiter="\t")
-        writer.writerow(header)
-        writer.writerows(bin_infos)
+    # Create pandas DataFrame and write to TSV
+    df = pd.DataFrame(data, columns=columns)
+    df.to_csv(output, sep="\t", index=False)
 
 
 def write_bins_fasta(

--- a/binette/main.py
+++ b/binette/main.py
@@ -153,6 +153,12 @@ def parse_arguments(args):
     runtime_group.add_argument(
         "-o", "--outdir", default=Path("results"), type=Path, help="Output directory."
     )
+    runtime_group.add_argument(
+        "--prefix",
+        type=str,
+        default="binette",
+        help="Prefix to add to final bin names (e.g. '--prefix sample1_' will produce 'sample1_bin1.fa', 'sample1_bin2.fa').",
+    )
 
     runtime_group.add_argument(
         "-t", "--threads", default=1, type=int, help="Number of threads to use."
@@ -604,10 +610,10 @@ def main():
     logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")
 
     bin_quality.add_bin_metrics(
-        contig_key_to_new_bin.values(),
-        contig_metadat,
-        args.contamination_weight,
-        args.threads,
+        bins=contig_key_to_new_bin.values(),
+        contig_info=contig_metadat,
+        contamination_weight=args.contamination_weight,
+        threads=args.threads,
     )
 
     contig_key_to_all_bin = contig_key_to_original_bin | contig_key_to_new_bin
@@ -625,6 +631,7 @@ def main():
         contig_key_to_all_bin,
         min_completeness=args.min_completeness,
         max_contamination=args.max_contamination,
+        prefix=args.prefix,
     )
 
     logging.info(f"Writing selected bins in {final_bin_report}")

--- a/tests/expected_results/final_bins_quality_reports.tsv
+++ b/tests/expected_results/final_bins_quality_reports.tsv
@@ -1,5 +1,5 @@
 name	origin	is_original	original_name	completeness	contamination	score	size	N50	contig_count
-binette_1	binette	False	binette_1	99.67	0.05	99.57	1043034	333900	3
-binette_2	B	True	binC	100.0	0.28	99.44	719535	378240	2
-binette_3	binette	False	binette_3	98.72	0.48	97.76	490885	133360	4
-binette_4	binette	False	binette_4	75.42	1.16	73.1	560035	39288	25
+binette_bin1	binette	False	binette_bin1	99.67	0.05	99.57	1043034	333900	3
+binette_bin2	B	True	binC	100.0	0.28	99.44	719535	378240	2
+binette_bin3	binette	False	binette_bin3	98.72	0.48	97.76	490885	133360	4
+binette_bin4	binette	False	binette_bin4	75.42	1.16	73.1	560035	39288	25


### PR DESCRIPTION
Small PR to add the possibility to add a prefix to the final bin names as requested in #61 . 

The prefix is used to name the final bins using this pattern : `<prefix>_bin<bin_id>` 
This name is used to name the fasta bin file and in the name column of the result file. 
By default the prefix is `binette`

