### PR TITLE
Speed Up Binette Startup Time

### DIFF
--- a/binette.yaml
+++ b/binette.yaml
@@ -16,4 +16,3 @@ dependencies:
   - pyfastx>=2,<4
   - pyrodigal
   - pyroaring>=1.0,<2.0
-  - lazy_loader>=0.2,<1.0

--- a/binette.yaml
+++ b/binette.yaml
@@ -16,3 +16,4 @@ dependencies:
   - pyfastx>=2,<4
   - pyrodigal
   - pyroaring>=1.0,<2.0
+  - lazy_loader>=0.2,<1.0

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 import logging
 import os
-import sys
 from collections import Counter, defaultdict
 from itertools import islice
 from typing import Dict, Iterable, Tuple, Iterator, List
 
-import lazy_loader as lazy
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -29,8 +27,6 @@ def get_modelPostprocessing():
     global _modelPostprocessing
     if _modelPostprocessing is None:
         # Only import keras when absolutely needed
-        sys.modules["keras"] = lazy.attach("keras")
-        sys.modules["keras.models"] = lazy.attach("keras.models")
         from checkm2 import modelPostprocessing
 
         _modelPostprocessing = modelPostprocessing
@@ -42,11 +38,10 @@ def get_modelProcessing():
     global _modelProcessing
     if _modelProcessing is None:
         # Only import keras when absolutely needed
-        sys.modules["keras"] = lazy.attach("keras")
-        sys.modules["keras.models"] = lazy.attach("keras.models")
         from checkm2 import modelProcessing
 
         _modelProcessing = modelProcessing
+
     return _modelProcessing
 
 

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -1,22 +1,53 @@
 #!/usr/bin/env python3
 import logging
 import os
-from collections import Counter
+import sys
+from collections import Counter, defaultdict
 from itertools import islice
-from typing import Dict, Iterable, Optional, Tuple, Iterator, List
+from typing import Dict, Iterable, Tuple, Iterator, List
 
+import lazy_loader as lazy
 import numpy as np
 import pandas as pd
-from binette.bin_manager import Bin
 from tqdm import tqdm
-from collections import defaultdict
+
+from binette.bin_manager import Bin
+from checkm2 import keggData
 
 # Suppress unnecessary TensorFlow warnings
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 logging.getLogger("tensorflow").setLevel(logging.FATAL)
 
+# Lazy loaders for checkm2 components that import keras
+# These will only be imported when explicitly called
+_modelPostprocessing = None
+_modelProcessing = None
 
-from checkm2 import keggData, modelPostprocessing, modelProcessing  # noqa: E402
+
+def get_modelPostprocessing():
+    """Lazy load modelPostprocessing module only when needed"""
+    global _modelPostprocessing
+    if _modelPostprocessing is None:
+        # Only import keras when absolutely needed
+        sys.modules["keras"] = lazy.attach("keras")
+        sys.modules["keras.models"] = lazy.attach("keras.models")
+        from checkm2 import modelPostprocessing
+
+        _modelPostprocessing = modelPostprocessing
+    return _modelPostprocessing
+
+
+def get_modelProcessing():
+    """Lazy load modelProcessing module only when needed"""
+    global _modelProcessing
+    if _modelProcessing is None:
+        # Only import keras when absolutely needed
+        sys.modules["keras"] = lazy.attach("keras")
+        sys.modules["keras.models"] = lazy.attach("keras.models")
+        from checkm2 import modelProcessing
+
+        _modelProcessing = modelProcessing
+    return _modelProcessing
 
 
 def get_bins_metadata_df(
@@ -300,6 +331,7 @@ def add_bin_metrics(
 
     :return: List of processed bin objects.
     """
+    modelPostprocessing = get_modelPostprocessing()
     postProcessor = modelPostprocessing.modelProcessor(threads)
 
     contig_to_kegg_counter = contig_info["contig_to_kegg_counter"]
@@ -340,7 +372,7 @@ def assess_bins_quality_by_chunk(
     contig_to_aa_counter: Dict,
     contig_to_aa_length: Dict,
     contamination_weight: float,
-    postProcessor: Optional[modelPostprocessing.modelProcessor] = None,
+    postProcessor=None,
     threads: int = 1,
     chunk_size: int = 2500,
     disable_bar=False,
@@ -384,7 +416,7 @@ def assess_bins_quality(
     contig_to_aa_counter: Dict,
     contig_to_aa_length: Dict,
     contamination_weight: float,
-    postProcessor: Optional[modelPostprocessing.modelProcessor] = None,
+    postProcessor=None,
     threads: int = 1,
 ):
     """
@@ -403,6 +435,7 @@ def assess_bins_quality(
     :param threads: Number of threads for parallel processing (default is 1).
     """
     if postProcessor is None:
+        modelPostprocessing = get_modelPostprocessing()
         postProcessor = modelPostprocessing.modelProcessor(threads)
 
     metadata_df = get_bins_metadata_df(
@@ -418,6 +451,7 @@ def assess_bins_quality(
     feature_vectors = feature_vectors.sort_values(by="Name")
 
     # 4: Call general model & specific models and derive predictions"""
+    modelProcessing = get_modelProcessing()
     modelProc = modelProcessing.modelProcessor(threads)
 
     vector_array = feature_vectors.iloc[:, 1:].values.astype(float)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,10 +65,8 @@ binette -h
 Binette is available on [PyPI](https://pypi.org/project/Binette/) and can be installed using pip as follows:
 
 ```bash
-pip install binette[main_deps]
+pip install binette
 ```
-
-Omitting the `[main_deps]` option will result in the installation of Binette without any Python dependencies.
 
 In addition to Python dependencies, Binette requires [Diamond](https://github.com/bbuchfink/diamond) to be installed and executable.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
     "pyfastx>=2,<3",
     "pyrodigal>=2,<3",
     "tqdm>=4,<5",
-    "pyroaring>=1.0.0,<2.0.0",
-    "lazy_loader>=0.2,<1.0",
+    "pyroaring>=1.0.0,<2.0.0"
 ]
 
 license = {file="LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,9 @@ classifiers=[
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics"]
 requires-python = ">=3.12"
-license = {file="LICENSE"}
 
-[project.optional-dependencies]
-main_deps = [
-    # "checkm2==1.1", # not yet on Pypi
+dependencies = [
+    "checkm2 @ git+https://github.com/chklovski/CheckM2.git@1.1.0",  # install CheckM2 v1.1.0 directly from GitHub because not properly packaged on PyPI
     "networkx>=3.0,<4.0",
     "numpy>1.24,<3.0",
     "pandas>=2,<3",
@@ -35,8 +33,12 @@ main_deps = [
     "pyrodigal>=2,<3",
     "tqdm>=4,<5",
     "pyroaring>=1.0.0,<2.0.0",
+    "lazy_loader>=0.2,<1.0",
 ]
 
+license = {file="LICENSE"}
+
+[project.optional-dependencies]
 doc = [
     "sphinx==6.2.1",
     "sphinx_rtd_theme==1.2.2",


### PR DESCRIPTION
Binette had slow startup (>2 seconds) because of CheckM2 and Keras/TensorFlow imports.

This PR adds a lazy loading to only import heavy dependencies when actually needed.
