### PR TITLE
Process bin quality assessemnt in parallel

### DIFF
--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Run simple test case from bin2table
       run: |
         cd test_data
-        binette -b binning_results/*binning --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results
+        binette -b binning_results/*binning --contigs all_contigs.fna --checkm2-db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results
 
     - name: Compare results from bin2table with expectation
       run: |
@@ -87,7 +87,7 @@ jobs:
     - name: Run simple test case from bin dirs
       run: |
         cd test_data
-        binette -d binning_results/A/ binning_results/B/ binning_results/C/  --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs
+        binette -d binning_results/A/ binning_results/B/ binning_results/C/  --contigs all_contigs.fna --checkm2-db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs
 
     - name: Compare results from bin dirs with expectation
       run: |
@@ -100,7 +100,7 @@ jobs:
       run: |
         cd test_data
         binette -d binning_results/A/ binning_results/B/ binning_results/C/ \
-                --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs_and_prot_input --proteins proteins.faa
+                --contigs all_contigs.fna --checkm2-db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs_and_prot_input --proteins proteins.faa
 
     - name: Compare results from bin dirs with expectation
       run: |

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Run simple test case from bin2table
       run: |
         cd test_data
-        binette -b binning_results/*binning --contigs all_contigs.fna --checkm2-db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results
+        binette -b binning_results/*binning --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results
 
     - name: Compare results from bin2table with expectation
       run: |
@@ -87,7 +87,7 @@ jobs:
     - name: Run simple test case from bin dirs
       run: |
         cd test_data
-        binette -d binning_results/A/ binning_results/B/ binning_results/C/  --contigs all_contigs.fna --checkm2-db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs
+        binette -d binning_results/A/ binning_results/B/ binning_results/C/  --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs
 
     - name: Compare results from bin dirs with expectation
       run: |
@@ -100,7 +100,7 @@ jobs:
       run: |
         cd test_data
         binette -d binning_results/A/ binning_results/B/ binning_results/C/ \
-                --contigs all_contigs.fna --checkm2-db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs_and_prot_input --proteins proteins.faa
+                --contigs all_contigs.fna --checkm2_db checkm2_tiny_db/checkm2_tiny_db.dmnd  -v -o test_results_from_dirs_and_prot_input --proteins proteins.faa
 
     - name: Compare results from bin dirs with expectation
       run: |

--- a/binette.yaml
+++ b/binette.yaml
@@ -16,3 +16,5 @@ dependencies:
   - pyfastx>=2,<4
   - pyrodigal
   - pyroaring>=1.0,<2.0
+  - typer>=0.9.0
+  - rich>=12.0.0

--- a/binette/bin_manager.py
+++ b/binette/bin_manager.py
@@ -7,7 +7,7 @@ import pyfastx
 import itertools
 import networkx as nx
 from typing import Any, List, Dict, Iterable, Tuple, Set, Optional
-from tqdm import tqdm
+from rich.progress import Progress
 
 from collections import Counter
 from pyroaring import BitMap
@@ -563,6 +563,7 @@ def create_intermediate_bins(
     max_conta: float,
     min_len: int,
     max_len: int,
+    disable_progress_bar: bool = False,
 ) -> Dict[bytes, Bin]:
     """
     Creates intermediate bins from a dictionary of bin sets.
@@ -600,50 +601,27 @@ def create_intermediate_bins(
 
     contig_key_to_new_contigs_set = {}
     discarded_contig_set_keys = set()
-    for clique in tqdm(
-        cliques_of_bins, total=len(cliques_of_bins), unit="clique of bins"
-    ):
-        bins_combinations = get_all_possible_combinations(clique)
+    with Progress(disable=disable_progress_bar) as progress:
+        task = progress.add_task(
+            f"Processing {len(cliques_of_bins)} cliques of bins",
+            total=len(cliques_of_bins),
+        )
+        for clique in cliques_of_bins:
+            progress.update(task, advance=1)
+            bins_combinations = get_all_possible_combinations(clique)
 
-        for bin_contig_keys in bins_combinations:
+            for bin_contig_keys in bins_combinations:
 
-            bins = [contig_key_to_initial_bin[ck] for ck in bin_contig_keys]
+                bins = [contig_key_to_initial_bin[ck] for ck in bin_contig_keys]
 
-            if all(b.completeness >= min_comp and b.length >= min_len for b in bins):
+                if all(
+                    b.completeness >= min_comp and b.length >= min_len for b in bins
+                ):
 
-                intersec_contigs = bins[0].contig_intersection(*bins[1:])
+                    intersec_contigs = bins[0].contig_intersection(*bins[1:])
 
-                if intersec_contigs:
-                    contig_key = intersec_contigs.serialize()
-
-                    if (
-                        contig_key not in contig_key_to_initial_bin
-                        and contig_key not in contig_key_to_new_contigs_set
-                        and contig_key not in discarded_contig_set_keys
-                    ):
-                        contigs_length = sum_contig_lengths(
-                            intersec_contigs,
-                            contig_lengths,
-                            cache=bin_length_cache,
-                            key=contig_key,
-                        )
-
-                        if contigs_length >= min_len and contigs_length <= max_len:
-                            contig_key_to_new_contigs_set[contig_key] = intersec_contigs
-                            intersec_count += 1
-                        else:
-                            discarded_contig_set_keys.add(contig_key)
-                            intersec_size_discarded_count += 1
-
-            for bin_a in bins:
-                if bin_a.completeness >= min_comp and bin_a.length >= min_len:
-
-                    diff_contigs = bin_a.contig_difference(
-                        *(b for b in bins if b != bin_a)
-                    )
-
-                    if diff_contigs:
-                        contig_key = diff_contigs.serialize()
+                    if intersec_contigs:
+                        contig_key = intersec_contigs.serialize()
 
                         if (
                             contig_key not in contig_key_to_initial_bin
@@ -651,41 +629,81 @@ def create_intermediate_bins(
                             and contig_key not in discarded_contig_set_keys
                         ):
                             contigs_length = sum_contig_lengths(
-                                diff_contigs,
+                                intersec_contigs,
                                 contig_lengths,
                                 cache=bin_length_cache,
                                 key=contig_key,
                             )
 
                             if contigs_length >= min_len and contigs_length <= max_len:
-                                contig_key_to_new_contigs_set[contig_key] = diff_contigs
-                                diff_count += 1
+                                contig_key_to_new_contigs_set[contig_key] = (
+                                    intersec_contigs
+                                )
+                                intersec_count += 1
                             else:
                                 discarded_contig_set_keys.add(contig_key)
-                                diff_size_discarded_count += 1
+                                intersec_size_discarded_count += 1
 
-            if all(b.contamination <= max_conta and b.length <= max_len for b in bins):
+                for bin_a in bins:
+                    if bin_a.completeness >= min_comp and bin_a.length >= min_len:
 
-                union_contigs = bins[0].contig_union(*bins[1:])
-                if union_contigs:
-                    contig_key = union_contigs.serialize()
-                    if (
-                        contig_key not in contig_key_to_initial_bin
-                        and contig_key not in contig_key_to_new_contigs_set
-                        and contig_key not in discarded_contig_set_keys
-                    ):
-                        contigs_length = sum_contig_lengths(
-                            union_contigs,
-                            contig_lengths,
-                            cache=bin_length_cache,
-                            key=contig_key,
+                        diff_contigs = bin_a.contig_difference(
+                            *(b for b in bins if b != bin_a)
                         )
-                        if contigs_length >= min_len and contigs_length <= max_len:
-                            contig_key_to_new_contigs_set[contig_key] = union_contigs
-                            union_count += 1
-                        else:
-                            discarded_contig_set_keys.add(contig_key)
-                            union_size_discarded_count += 1
+
+                        if diff_contigs:
+                            contig_key = diff_contigs.serialize()
+
+                            if (
+                                contig_key not in contig_key_to_initial_bin
+                                and contig_key not in contig_key_to_new_contigs_set
+                                and contig_key not in discarded_contig_set_keys
+                            ):
+                                contigs_length = sum_contig_lengths(
+                                    diff_contigs,
+                                    contig_lengths,
+                                    cache=bin_length_cache,
+                                    key=contig_key,
+                                )
+
+                                if (
+                                    contigs_length >= min_len
+                                    and contigs_length <= max_len
+                                ):
+                                    contig_key_to_new_contigs_set[contig_key] = (
+                                        diff_contigs
+                                    )
+                                    diff_count += 1
+                                else:
+                                    discarded_contig_set_keys.add(contig_key)
+                                    diff_size_discarded_count += 1
+
+                if all(
+                    b.contamination <= max_conta and b.length <= max_len for b in bins
+                ):
+
+                    union_contigs = bins[0].contig_union(*bins[1:])
+                    if union_contigs:
+                        contig_key = union_contigs.serialize()
+                        if (
+                            contig_key not in contig_key_to_initial_bin
+                            and contig_key not in contig_key_to_new_contigs_set
+                            and contig_key not in discarded_contig_set_keys
+                        ):
+                            contigs_length = sum_contig_lengths(
+                                union_contigs,
+                                contig_lengths,
+                                cache=bin_length_cache,
+                                key=contig_key,
+                            )
+                            if contigs_length >= min_len and contigs_length <= max_len:
+                                contig_key_to_new_contigs_set[contig_key] = (
+                                    union_contigs
+                                )
+                                union_count += 1
+                            else:
+                                discarded_contig_set_keys.add(contig_key)
+                                union_size_discarded_count += 1
 
     logging.info(
         f"Intersection: {intersec_count} bins created, {intersec_size_discarded_count} discarded due to size constraints."

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -8,8 +8,9 @@ from typing import Dict, Iterable, Optional, Tuple, Iterator, List
 import numpy as np
 import pandas as pd
 from binette.bin_manager import Bin
-from tqdm import tqdm
 from collections import defaultdict
+from rich.progress import Progress
+
 
 # Suppress unnecessary TensorFlow warnings
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -288,6 +289,7 @@ def add_bin_metrics(
     contamination_weight: float,
     threads: int = 1,
     chunk_size: int = 5000,
+    disable_progress_bar: bool = False,
 ):
     """
     Add metrics to a Set of bins.
@@ -297,6 +299,7 @@ def add_bin_metrics(
     :param contamination_weight: Weight for contamination assessment.
     :param threads: Number of threads for parallel processing (default is 1).
     :param chunk_size: Number of bins to process in each chunk (default is 5000).
+    :param disable_progress_bar: Disable the progress bar if True.
 
     :return: List of processed bin objects.
     """
@@ -317,6 +320,7 @@ def add_bin_metrics(
         contamination_weight,
         postProcessor,
         chunk_size=chunk_size,
+        disable_progress_bar=disable_progress_bar,
     )
     return bins
 
@@ -343,7 +347,7 @@ def assess_bins_quality_by_chunk(
     postProcessor: Optional[modelPostprocessing.modelProcessor] = None,
     threads: int = 1,
     chunk_size: int = 2500,
-    disable_bar=False,
+    disable_progress_bar=False,
 ):
     """
     Assess the quality of bins in chunks.
@@ -359,12 +363,14 @@ def assess_bins_quality_by_chunk(
     :param postProcessor: post-processor from checkm2
     :param threads: Number of threads for parallel processing (default is 1).
     :param chunk_size: The size of each chunk.
+    :param disable_progress_bar: Disable the progress bar if True.
     """
-    with tqdm(total=len(bins), unit="bin", disable=disable_bar) as pbar:
+    with Progress(disable=disable_progress_bar) as progress:
+        task = progress.add_task("Assessing bin quality", total=len(bins))
         for i, chunk_bins_iter in enumerate(chunks(bins, chunk_size)):
             chunk_bins = list(chunk_bins_iter)
             logging.debug(f"chunk {i}: assessing quality of {len(chunk_bins)} bins")
-            bins_scored = assess_bins_quality(
+            assess_bins_quality(
                 bins=chunk_bins,
                 contig_to_kegg_counter=contig_to_kegg_counter,
                 contig_to_cds_count=contig_to_cds_count,
@@ -374,7 +380,7 @@ def assess_bins_quality_by_chunk(
                 postProcessor=postProcessor,
                 threads=threads,
             )
-            pbar.update(len(bins_scored))
+            progress.update(task, advance=len(chunk_bins))
 
 
 def assess_bins_quality(

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -8,12 +8,10 @@ from typing import Dict, Iterable, Tuple, Iterator, List
 import numpy as np
 import pandas as pd
 from binette.bin_manager import Bin
-from collections import defaultdict
 from rich.progress import Progress
 
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from binette.bin_manager import Bin
 from checkm2 import keggData
 
 # Suppress unnecessary TensorFlow warnings

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -24,12 +24,47 @@ logging.getLogger("tensorflow").setLevel(logging.FATAL)
 # These will only be imported when explicitly called
 _modelPostprocessing = None
 _modelProcessing = None
+_keras_initialized = False
+
+
+def _initialize_keras_environment():
+    """Initialize TensorFlow/Keras to ensure thread safety and memory management"""
+    global _keras_initialized
+    if not _keras_initialized:
+        # This helps avoid memory leaks and threading issues
+        import os
+
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # Suppress TF warnings
+
+        try:
+            # Only import keras-related modules when needed
+            import tensorflow as tf
+
+            # Set memory growth to avoid OOM errors
+            gpus = tf.config.experimental.list_physical_devices("GPU")
+            if gpus:
+                for gpu in gpus:
+                    tf.config.experimental.set_memory_growth(gpu, True)
+
+            # Use a single thread for predictions to avoid thread contention
+            tf.config.threading.set_intra_op_parallelism_threads(1)
+            tf.config.threading.set_inter_op_parallelism_threads(1)
+
+            _keras_initialized = True
+            logging.debug("TensorFlow/Keras environment initialized")
+        except Exception as e:
+            logging.warning(
+                f"Failed to fully initialize TensorFlow environment: {str(e)}"
+            )
 
 
 def get_modelPostprocessing():
     """Lazy load modelPostprocessing module only when needed"""
     global _modelPostprocessing
     if _modelPostprocessing is None:
+        # Initialize Keras environment
+        _initialize_keras_environment()
+
         # Only import keras when absolutely needed
         from checkm2 import modelPostprocessing
 
@@ -41,6 +76,9 @@ def get_modelProcessing():
     """Lazy load modelProcessing module only when needed"""
     global _modelProcessing
     if _modelProcessing is None:
+        # Initialize Keras environment
+        _initialize_keras_environment()
+
         # Only import keras when absolutely needed
         from checkm2 import modelProcessing
 
@@ -326,26 +364,48 @@ def add_bin_metrics(
     :param bins: Set of bin objects.
     :param contig_info: Dictionary containing contig information.
     :param contamination_weight: Weight for contamination assessment.
-    :param threads: Number of threads for parallel processing (default is 1).
+    :param threads: Number of threads/processes for parallel processing (default is 1).
     :param chunk_size: Number of bins to process in each chunk (default is 5000).
     :param disable_progress_bar: Disable the progress bar if True.
 
     :return: List of processed bin objects.
     """
-    modelPostprocessing = get_modelPostprocessing()
-    postProcessor = modelPostprocessing.modelProcessor(threads)
+    if not bins:
+        logging.warning("No bins provided for quality assessment")
+        return []
 
+    logging.info(f"Assessing bin quality for {len(bins)} bins using {threads} threads.")
+
+    # Initialize in the main process
+    modelPostprocessing = get_modelPostprocessing()
+    postProcessor = modelPostprocessing.modelProcessor(
+        1
+    )  # Use 1 thread for main process
+
+    # Extract data from contig_info
     contig_to_kegg_counter = contig_info["contig_to_kegg_counter"]
     contig_to_cds_count = contig_info["contig_to_cds_count"]
     contig_to_aa_counter = contig_info["contig_to_aa_counter"]
     contig_to_aa_length = contig_info["contig_to_aa_length"]
 
-    parallel_chunks = threads
+    # Configure parallel execution
+    # If threads=1, use sequential processing
+    # Otherwise, use parallel processing with threads-1 processes
+    # and 1 thread per worker process
+    parallel_chunks = max(1, threads - 1) if threads > 1 else 0
     model_threads = 1
-    logging.info(f"Assessing bin quality for {len(bins)} bins.")
+
+    # Adjust chunk size based on number of bins and processes
+    if len(bins) < chunk_size and parallel_chunks > 1:
+        # If we have fewer bins than chunk size, reduce chunk size to distribute work
+        adjusted_chunk_size = max(1, len(bins) // parallel_chunks)
+        chunk_size = min(chunk_size, adjusted_chunk_size)
+
     logging.debug(
         f"Using chunk size of {chunk_size} and parallel chunks of {parallel_chunks}."
     )
+
+    # Process bins in chunks
     bins = assess_bins_quality_by_chunk(
         bins,
         contig_to_kegg_counter,
@@ -355,7 +415,7 @@ def add_bin_metrics(
         contamination_weight,
         postProcessor,
         chunk_size=chunk_size,
-        parallel_chunks=threads,
+        parallel_chunks=parallel_chunks,
         threads=model_threads,
         disable_progress_bar=disable_progress_bar,
     )
@@ -387,18 +447,41 @@ def _process_chunk(
     """
     Worker function for processing a chunk of bins.
     Each worker creates its own modelProcessor instance.
+
+    This function runs in a separate process, so we need to ensure all
+    objects can be properly pickled/unpickled.
     """
-    # We do NOT pass postProcessor here to avoid cross-process object sharing
-    return assess_bins_quality(
-        bins=chunk_bins,
-        contig_to_kegg_counter=contig_to_kegg_counter,
-        contig_to_cds_count=contig_to_cds_count,
-        contig_to_aa_counter=contig_to_aa_counter,
-        contig_to_aa_length=contig_to_aa_length,
-        contamination_weight=contamination_weight,
-        postProcessor=None,
-        threads=threads,
-    )
+    # Initialize logging in subprocess to avoid sharing logging handlers
+    logging.basicConfig(level=logging.INFO)
+
+    try:
+        # We explicitly create our own postProcessor here rather than sharing
+        modelPostprocessing = get_modelPostprocessing()
+        local_postProcessor = modelPostprocessing.modelProcessor(threads)
+
+        # Process the bins
+        result = assess_bins_quality(
+            bins=chunk_bins,
+            contig_to_kegg_counter=contig_to_kegg_counter,
+            contig_to_cds_count=contig_to_cds_count,
+            contig_to_aa_counter=contig_to_aa_counter,
+            contig_to_aa_length=contig_to_aa_length,
+            contamination_weight=contamination_weight,
+            postProcessor=local_postProcessor,
+            threads=threads,
+        )
+
+        # Clean up to help with memory management
+        import gc
+
+        del local_postProcessor
+        gc.collect()
+
+        return result
+    except Exception as e:
+        logging.error(f"Error in worker process: {str(e)}")
+        # Return empty list if processing failed
+        return []
 
 
 def assess_bins_quality_by_chunk(
@@ -414,8 +497,15 @@ def assess_bins_quality_by_chunk(
     parallel_chunks: int = 1,
     disable_progress_bar: bool = False,
 ):
+    """
+    Assess bins quality in chunks, optionally using multiple processes.
+
+    This function can process chunks sequentially or in parallel using ProcessPoolExecutor.
+
+    :return: List of processed bin objects with quality metrics added.
+    """
     bins = list(bins)
-    chunks_list = [chunk for chunk in chunks(bins, chunk_size)]
+    chunks_list = list(chunks(bins, chunk_size))
 
     logging.info(
         f"Assessing quality of {len(bins)} bins in {len(chunks_list)} chunks "
@@ -423,6 +513,11 @@ def assess_bins_quality_by_chunk(
     )
 
     bins_scored = []
+
+    # Handle empty bins list
+    if not bins:
+        logging.warning("No bins to process")
+        return bins_scored
 
     # Cap parallel_chunks to number of chunks
     parallel_chunks = min(parallel_chunks, len(chunks_list))
@@ -432,27 +527,49 @@ def assess_bins_quality_by_chunk(
 
         if parallel_chunks > 1:
             # Multiprocessing mode
-            with ProcessPoolExecutor(max_workers=parallel_chunks) as executor:
-                futures = {
-                    executor.submit(
-                        _process_chunk,
-                        chunk_bins,
-                        contig_to_kegg_counter,
-                        contig_to_cds_count,
-                        contig_to_aa_counter,
-                        contig_to_aa_length,
-                        contamination_weight,
-                        threads,
-                    ): chunk_bins
-                    for chunk_bins in chunks_list
-                }
+            try:
+                logging.debug(
+                    f"Starting multiprocessing with {parallel_chunks} workers"
+                )
+                with ProcessPoolExecutor(max_workers=parallel_chunks) as executor:
+                    # Submit all jobs first
+                    futures = []
+                    for chunk_bins in chunks_list:
+                        futures.append(
+                            executor.submit(
+                                _process_chunk,
+                                chunk_bins,
+                                contig_to_kegg_counter,
+                                contig_to_cds_count,
+                                contig_to_aa_counter,
+                                contig_to_aa_length,
+                                contamination_weight,
+                                threads,
+                            )
+                        )
 
-                for future in as_completed(futures):
-                    chunk_bins_scored = future.result()
-                    bins_scored.extend(chunk_bins_scored)
-                    progress.update(task, advance=len(chunk_bins_scored))
+                    # Process results as they complete
+                    for future in as_completed(futures):
+                        try:
+                            chunk_bins_scored = future.result()
+                            bins_scored.extend(chunk_bins_scored)
+                            progress.update(task, advance=len(chunk_bins_scored))
+                        except Exception as e:
+                            logging.error(f"Error in worker process: {str(e)}")
+                            # Continue with other chunks if one fails
+                            continue
+            except Exception as e:
+                logging.error(
+                    f"Multiprocessing failed: {str(e)}. Falling back to sequential mode."
+                )
+                # Reset progress
+                progress.update(task, completed=0)
+                bins_scored = []
+                # Fall back to sequential mode
+                parallel_chunks = 0
 
-        else:
+        # Either sequential mode was requested or multiprocessing failed
+        if parallel_chunks <= 1:
             # Sequential mode
             for i, chunk_bins in enumerate(chunks_list):
                 logging.debug(f"chunk {i}: assessing quality of {len(chunk_bins)} bins")

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -30,8 +30,6 @@ def _initialize_keras_environment():
     """Initialize TensorFlow/Keras to ensure thread safety and memory management"""
     global _keras_initialized
     if not _keras_initialized:
-        # This helps avoid memory leaks and threading issues
-        import os
 
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"  # Suppress TF warnings
 
@@ -354,7 +352,7 @@ def add_bin_metrics(
     contig_info: Dict,
     contamination_weight: float,
     threads: int = 1,
-    checkm2_batch_size: int = 600,
+    checkm2_batch_size: int = 500,
     disable_progress_bar: bool = False,
 ):
     """
@@ -368,9 +366,8 @@ def add_bin_metrics(
                     If threads>1, processing is parallelized across multiple processes.
                     The number of parallel workers will be approximately equal to threads.
     :param checkm2_batch_size: Maximum number of bins to send to CheckM2 at once within each process
-                              to control memory usage (default is 600). This creates sub-batches
+                              to control memory usage. This creates sub-batches
                               within each worker to manage CheckM2's memory consumption.
-                              Can be overridden by BINETTE_CHECKM2_BATCH_SIZE env variable.
     :param disable_progress_bar: Disable the progress bar if True.
 
     :return: List of processed bin objects with quality metrics added.
@@ -379,20 +376,8 @@ def add_bin_metrics(
         logging.warning("No bins provided for quality assessment")
         return []
 
-    # Override checkm2_batch_size from environment variable if set
-    env_batch_size = os.environ.get("BINETTE_CHECKM2_BATCH_SIZE")
-    if env_batch_size:
-        try:
-            checkm2_batch_size = int(env_batch_size)
-            logging.info(
-                f"Using CheckM2 batch size from environment: {checkm2_batch_size}"
-            )
-        except ValueError:
-            logging.warning(
-                f"Invalid BINETTE_CHECKM2_BATCH_SIZE value: {env_batch_size}, using default: {checkm2_batch_size}"
-            )
-
     bins_list = list(bins)
+
     logging.info(
         f"Assessing bin quality for {len(bins_list)} bins using {threads} threads."
     )
@@ -419,45 +404,19 @@ def add_bin_metrics(
             checkm2_batch_size=checkm2_batch_size,
         )
 
-    # Use sequential processing if only 1 thread, few bins, or small dataset
-    # Use 2x batch size as threshold to avoid multiprocessing overhead for small datasets
-    sequential_threshold = checkm2_batch_size * 2
-    if threads == 1 or len(bins_list) <= sequential_threshold:
-        if len(bins_list) <= sequential_threshold:
+    min_bins_per_chunk = checkm2_batch_size * 6
+
+    if threads == 1 or len(bins_list) <= min_bins_per_chunk * 2:
+        if len(bins_list) <= min_bins_per_chunk:
             logging.info(
-                f"Only {len(bins_list)} bins (≤ {sequential_threshold}). Using sequential processing to avoid multiprocessing overhead."
+                f"Only {len(bins_list)} bins (≤ {min_bins_per_chunk}). Using sequential processing to avoid multiprocessing overhead."
             )
         return _process_sequential()
+
     # For parallel processing, use joblib
-
-    # Get chunk multiplier from environment variable for testing
-    env_chunk_multiplier = os.environ.get("BINETTE_CHUNK_MULTIPLIER")
-    if env_chunk_multiplier:
-        try:
-            chunk_multiplier = float(env_chunk_multiplier)
-            logging.info(f"Using chunk multiplier from environment: {chunk_multiplier}")
-        except ValueError:
-            logging.warning(
-                f"Invalid BINETTE_CHUNK_MULTIPLIER value: {env_chunk_multiplier}, using default logic"
-            )
-            chunk_multiplier = None
-    else:
-        chunk_multiplier = None
-
-    # Calculate number of chunks based on environment variable or default logic
-    if chunk_multiplier is not None:
-        # Use environment-specified multiplier for testing
-        n_chunks = max(1, int(threads * chunk_multiplier))
-        logging.info(
-            f"Using {chunk_multiplier}x chunk multiplier: {threads} threads → {n_chunks} chunks"
-        )
-    else:
-        # Use default logic (simple threshold-based)
-        n_chunks = threads if len(bins_list) < 50_000 else threads * 2
-        strategy = "static" if len(bins_list) < 50_000 else "2x load balancing"
-        logging.info(
-            f"Using default chunking strategy ({strategy}): {threads} threads → {n_chunks} chunks"
-        )
+    # Calculate number of chunks ensuring each chunk has sufficient work
+    max_possible_chunks = len(bins_list) // min_bins_per_chunk
+    n_chunks = max(1, min(threads * 2, max_possible_chunks))
 
     n_jobs = min(threads, n_chunks)
     # Use balanced chunking to distribute work evenly across available threads
@@ -506,8 +465,8 @@ def add_bin_metrics(
     with Progress(disable=disable_progress_bar) as progress:
         task = progress.add_task("Assessing bin quality", total=len(bins_list))
 
-        # Use joblib for parallelization - it handles many complexities automatically
-        results = joblib.Parallel(n_jobs=n_jobs, verbose=0)(
+        # Use joblib for parallelization
+        results = joblib.Parallel(n_jobs=n_jobs)(
             joblib.delayed(process_chunk)(chunk) for chunk in chunks_list
         )
 
@@ -588,7 +547,7 @@ def assess_bins_quality(
     :param contamination_weight: Weight for contamination assessment.
     :param postProcessor: A post-processor from checkm2
     :param threads: Number of threads for parallel processing (default is 1).
-    :param checkm2_batch_size: Maximum number of bins to process in a single CheckM2 call (default is 500).
+    :param checkm2_batch_size: Maximum number of bins to process in a single CheckM2 call.
     """
     if postProcessor is None:
         modelPostprocessing = get_modelPostprocessing()

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -11,8 +11,8 @@ from binette.bin_manager import Bin
 from rich.progress import Progress
 
 
-from concurrent.futures import ProcessPoolExecutor, as_completed
 from checkm2 import keggData
+import joblib
 
 # Suppress unnecessary TensorFlow warnings
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
@@ -362,23 +362,23 @@ def add_bin_metrics(
     :param bins: Set of bin objects.
     :param contig_info: Dictionary containing contig information.
     :param contamination_weight: Weight for contamination assessment.
-    :param threads: Number of threads/processes for parallel processing (default is 1).
+    :param threads: Number of threads for parallel processing (default is 1).
+                    If threads=1, all processing happens sequentially using one thread.
+                    If threads>1, processing is parallelized across multiple processes 
+                    with threads distributed across workers.
     :param chunk_size: Number of bins to process in each chunk (default is 5000).
     :param disable_progress_bar: Disable the progress bar if True.
 
-    :return: List of processed bin objects.
+    :return: List of processed bin objects with quality metrics added.
     """
     if not bins:
         logging.warning("No bins provided for quality assessment")
         return []
 
-    logging.info(f"Assessing bin quality for {len(bins)} bins using {threads} threads.")
-
-    # Initialize in the main process
-    modelPostprocessing = get_modelPostprocessing()
-    postProcessor = modelPostprocessing.modelProcessor(
-        1
-    )  # Use 1 thread for main process
+    bins_list = list(bins)
+    logging.info(
+        f"Assessing bin quality for {len(bins_list)} bins using {threads} threads."
+    )
 
     # Extract data from contig_info
     contig_to_kegg_counter = contig_info["contig_to_kegg_counter"]
@@ -386,39 +386,76 @@ def add_bin_metrics(
     contig_to_aa_counter = contig_info["contig_to_aa_counter"]
     contig_to_aa_length = contig_info["contig_to_aa_length"]
 
-    # Configure parallel execution
-    # If threads=1, use sequential processing
-    # Otherwise, use parallel processing with threads-1 processes
-    # and 1 thread per worker process
-    parallel_chunks = max(1, threads - 1) if threads > 1 else 0
-    model_threads = 1
+    # Simple sequential processing if only 1 thread or few bins
+    if threads == 1 or len(bins_list) <= 1:
+        # Initialize in the main process
+        modelPostprocessing = get_modelPostprocessing()
+        postProcessor = modelPostprocessing.modelProcessor(threads)  # Use all threads
 
-    # Adjust chunk size based on number of bins and processes
-    if len(bins) < chunk_size and parallel_chunks > 1:
-        # If we have fewer bins than chunk size, reduce chunk size to distribute work
-        adjusted_chunk_size = max(1, len(bins) // parallel_chunks)
-        chunk_size = min(chunk_size, adjusted_chunk_size)
+        # Process all bins at once with sequential processing
+        return assess_bins_quality(
+            bins=bins_list,
+            contig_to_kegg_counter=contig_to_kegg_counter,
+            contig_to_cds_count=contig_to_cds_count,
+            contig_to_aa_counter=contig_to_aa_counter,
+            contig_to_aa_length=contig_to_aa_length,
+            contamination_weight=contamination_weight,
+            postProcessor=postProcessor,
+            threads=threads,  # Use all available threads in sequential mode
+        )
+    else:
+        # For parallel processing, use joblib
 
-    logging.debug(
-        f"Using chunk size of {chunk_size} and parallel chunks of {parallel_chunks}."
-    )
+        # Split bins into chunks for better parallelism
+        chunks_list = list(chunks(bins_list, chunk_size))
+        n_chunks = len(chunks_list)
+        n_jobs = min(threads, n_chunks)
 
-    # Process bins in chunks
-    bins = assess_bins_quality_by_chunk(
-        bins,
-        contig_to_kegg_counter,
-        contig_to_cds_count,
-        contig_to_aa_counter,
-        contig_to_aa_length,
-        contamination_weight,
-        postProcessor,
-        chunk_size=chunk_size,
-        parallel_chunks=parallel_chunks,
-        threads=model_threads,
-        disable_progress_bar=disable_progress_bar,
-    )
+        logging.info(
+            f"Using {n_jobs} parallel jobs to process {n_chunks} chunks of bins"
+        )
 
-    return bins
+        # Define a simple function to process a chunk
+        def process_chunk(chunk_bins):
+            # Initialize TensorFlow/Keras environment for this subprocess
+            _initialize_keras_environment()
+            
+            # Determine optimal thread count for this worker
+            # For best efficiency, we allocate a portion of total threads to each worker
+            # Math.ceil(total_threads / n_jobs) would be most aggressive
+            # But we use 1 thread per worker as the default to avoid oversubscription
+            worker_threads = max(1, threads // (2 * n_jobs))  # Conservative thread allocation
+            
+            # Create local processor instance
+            modelPostprocessing = get_modelPostprocessing()
+            local_postProcessor = modelPostprocessing.modelProcessor(worker_threads)
+            
+            # Process bins
+            return assess_bins_quality(
+                bins=chunk_bins,
+                contig_to_kegg_counter=contig_to_kegg_counter,
+                contig_to_cds_count=contig_to_cds_count,
+                contig_to_aa_counter=contig_to_aa_counter,
+                contig_to_aa_length=contig_to_aa_length,
+                contamination_weight=contamination_weight,
+                postProcessor=local_postProcessor,
+                threads=worker_threads,  # Use allocated threads in each worker
+            )        # Process chunks in parallel using joblib
+        with Progress(disable=disable_progress_bar) as progress:
+            task = progress.add_task("Assessing bin quality", total=len(bins_list))
+
+            # Use joblib for parallelization - it handles many complexities automatically
+            results = joblib.Parallel(n_jobs=n_jobs, verbose=0)(
+                joblib.delayed(process_chunk)(chunk) for chunk in chunks_list
+            )
+
+            # Combine results
+            all_bins = []
+            for chunk_result in results:
+                all_bins.extend(chunk_result)
+                progress.update(task, advance=len(chunk_result))
+
+            return all_bins
 
 
 def chunks(iterable: Iterable, size: int) -> Iterator[Tuple]:
@@ -431,206 +468,6 @@ def chunks(iterable: Iterable, size: int) -> Iterator[Tuple]:
     """
     it = iter(iterable)
     return iter(lambda: tuple(islice(it, size)), ())
-
-
-def _process_chunk(
-    chunk_bins,
-    contig_to_kegg_counter,
-    contig_to_cds_count,
-    contig_to_aa_counter,
-    contig_to_aa_length,
-    contamination_weight,
-    threads,
-):
-    """
-    Worker function for processing a chunk of bins.
-    Each worker creates its own modelProcessor instance.
-
-    This function runs in a separate process, so we need to ensure all
-    objects can be properly pickled/unpickled.
-    """
-    # Initialize logging in subprocess to avoid sharing logging handlers
-    logging.basicConfig(level=logging.INFO)
-
-    try:
-        # We explicitly create our own postProcessor here rather than sharing
-        modelPostprocessing = get_modelPostprocessing()
-        local_postProcessor = modelPostprocessing.modelProcessor(threads)
-
-        # Process the bins
-        result = assess_bins_quality(
-            bins=chunk_bins,
-            contig_to_kegg_counter=contig_to_kegg_counter,
-            contig_to_cds_count=contig_to_cds_count,
-            contig_to_aa_counter=contig_to_aa_counter,
-            contig_to_aa_length=contig_to_aa_length,
-            contamination_weight=contamination_weight,
-            postProcessor=local_postProcessor,
-            threads=threads,
-        )
-
-        # Clean up to help with memory management
-        import gc
-
-        del local_postProcessor
-        gc.collect()
-
-        return result
-    except Exception as e:
-        logging.error(f"Error in worker process: {str(e)}")
-        # Return empty list if processing failed
-        return []
-
-
-def assess_bins_quality_by_chunk(
-    bins,
-    contig_to_kegg_counter,
-    contig_to_cds_count,
-    contig_to_aa_counter,
-    contig_to_aa_length,
-    contamination_weight,
-    postProcessor=None,
-    threads: int = 1,
-    chunk_size: int = 2500,
-    parallel_chunks: int = 1,
-    disable_progress_bar: bool = False,
-):
-    """
-    Assess bins quality in chunks, optionally using multiple processes.
-
-    This function can process chunks sequentially or in parallel using ProcessPoolExecutor.
-
-    :return: List of processed bin objects with quality metrics added.
-    """
-    bins = list(bins)
-    chunks_list = list(chunks(bins, chunk_size))
-
-    logging.info(
-        f"Assessing quality of {len(bins)} bins in {len(chunks_list)} chunks "
-        f"(parallel_chunks={parallel_chunks}, threads={threads})"
-    )
-
-    bins_scored = []
-
-    # Handle empty bins list
-    if not bins:
-        logging.warning("No bins to process")
-        return bins_scored
-
-    # Cap parallel_chunks to number of chunks
-    parallel_chunks = min(parallel_chunks, len(chunks_list))
-
-    with Progress(disable=disable_progress_bar) as progress:
-        task = progress.add_task("Assessing bin quality", total=len(bins))
-
-        if parallel_chunks > 1:
-            # Multiprocessing mode
-            try:
-                logging.debug(
-                    f"Starting multiprocessing with {parallel_chunks} workers"
-                )
-                with ProcessPoolExecutor(max_workers=parallel_chunks) as executor:
-                    # Submit all jobs first
-                    futures = []
-                    for chunk_bins in chunks_list:
-                        futures.append(
-                            executor.submit(
-                                _process_chunk,
-                                chunk_bins,
-                                contig_to_kegg_counter,
-                                contig_to_cds_count,
-                                contig_to_aa_counter,
-                                contig_to_aa_length,
-                                contamination_weight,
-                                threads,
-                            )
-                        )
-
-                    # Process results as they complete
-                    for future in as_completed(futures):
-                        try:
-                            chunk_bins_scored = future.result()
-                            bins_scored.extend(chunk_bins_scored)
-                            progress.update(task, advance=len(chunk_bins_scored))
-                        except Exception as e:
-                            logging.error(f"Error in worker process: {str(e)}")
-                            # Continue with other chunks if one fails
-                            continue
-            except Exception as e:
-                logging.error(
-                    f"Multiprocessing failed: {str(e)}. Falling back to sequential mode."
-                )
-                # Reset progress
-                progress.update(task, completed=0)
-                bins_scored = []
-                # Fall back to sequential mode
-                parallel_chunks = 0
-
-        # Either sequential mode was requested or multiprocessing failed
-        if parallel_chunks <= 1:
-            # Sequential mode
-            for i, chunk_bins in enumerate(chunks_list):
-                logging.debug(f"chunk {i}: assessing quality of {len(chunk_bins)} bins")
-                chunk_bins_scored = assess_bins_quality(
-                    bins=chunk_bins,
-                    contig_to_kegg_counter=contig_to_kegg_counter,
-                    contig_to_cds_count=contig_to_cds_count,
-                    contig_to_aa_counter=contig_to_aa_counter,
-                    contig_to_aa_length=contig_to_aa_length,
-                    contamination_weight=contamination_weight,
-                    postProcessor=postProcessor,
-                    threads=threads,
-                )
-                bins_scored.extend(chunk_bins_scored)
-                progress.update(task, advance=len(chunk_bins_scored))
-
-    return bins_scored
-
-
-def assess_bins_quality_by_chunk_old(
-    bins: Iterable[Bin],
-    contig_to_kegg_counter: Dict,
-    contig_to_cds_count: Dict,
-    contig_to_aa_counter: Dict,
-    contig_to_aa_length: Dict,
-    contamination_weight: float,
-    postProcessor=None,
-    threads: int = 1,
-    chunk_size: int = 2500,
-    disable_progress_bar=False,
-):
-    """
-    Assess the quality of bins in chunks.
-
-    This function assesses the quality of bins in chunks to improve processing efficiency.
-
-    :param bins: List of bin objects.
-    :param contig_to_kegg_counter: Dictionary mapping contig names to KEGG counters.
-    :param contig_to_cds_count: Dictionary mapping contig names to CDS counts.
-    :param contig_to_aa_counter: Dictionary mapping contig names to amino acid counters.
-    :param contig_to_aa_length: Dictionary mapping contig names to amino acid lengths.
-    :param contamination_weight: Weight for contamination assessment.
-    :param postProcessor: post-processor from checkm2
-    :param threads: Number of threads for parallel processing (default is 1).
-    :param chunk_size: The size of each chunk.
-    :param disable_progress_bar: Disable the progress bar if True.
-    """
-    with Progress(disable=disable_progress_bar) as progress:
-        task = progress.add_task("Assessing bin quality", total=len(bins))
-        for i, chunk_bins_iter in enumerate(chunks(bins, chunk_size)):
-            chunk_bins = list(chunk_bins_iter)
-            logging.debug(f"chunk {i}: assessing quality of {len(chunk_bins)} bins")
-            assess_bins_quality(
-                bins=chunk_bins,
-                contig_to_kegg_counter=contig_to_kegg_counter,
-                contig_to_cds_count=contig_to_cds_count,
-                contig_to_aa_counter=contig_to_aa_counter,
-                contig_to_aa_length=contig_to_aa_length,
-                contamination_weight=contamination_weight,
-                postProcessor=postProcessor,
-                threads=threads,
-            )
-            progress.update(task, advance=len(chunk_bins))
 
 
 def assess_bins_quality(

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import gc
 import logging
 import os
 from collections import Counter, defaultdict
@@ -353,7 +354,7 @@ def add_bin_metrics(
     contig_info: Dict,
     contamination_weight: float,
     threads: int = 1,
-    chunk_size: int = 5000,
+    checkm2_batch_size: int = 600,
     disable_progress_bar: bool = False,
 ):
     """
@@ -364,9 +365,11 @@ def add_bin_metrics(
     :param contamination_weight: Weight for contamination assessment.
     :param threads: Number of threads for parallel processing (default is 1).
                     If threads=1, all processing happens sequentially using one thread.
-                    If threads>1, processing is parallelized across multiple processes 
-                    with threads distributed across workers.
-    :param chunk_size: Number of bins to process in each chunk (default is 5000).
+                    If threads>1, processing is parallelized across multiple processes.
+                    The number of parallel workers will be approximately equal to threads.
+    :param checkm2_batch_size: Maximum number of bins to send to CheckM2 at once within each process
+                              to control memory usage (default is 500). This creates sub-batches
+                              within each worker to manage CheckM2's memory consumption.
     :param disable_progress_bar: Disable the progress bar if True.
 
     :return: List of processed bin objects with quality metrics added.
@@ -386,13 +389,10 @@ def add_bin_metrics(
     contig_to_aa_counter = contig_info["contig_to_aa_counter"]
     contig_to_aa_length = contig_info["contig_to_aa_length"]
 
-    # Simple sequential processing if only 1 thread or few bins
-    if threads == 1 or len(bins_list) <= 1:
-        # Initialize in the main process
+    def _process_sequential():
+        """Helper function for sequential processing"""
         modelPostprocessing = get_modelPostprocessing()
-        postProcessor = modelPostprocessing.modelProcessor(threads)  # Use all threads
-
-        # Process all bins at once with sequential processing
+        postProcessor = modelPostprocessing.modelProcessor(threads)
         return assess_bins_quality(
             bins=bins_list,
             contig_to_kegg_counter=contig_to_kegg_counter,
@@ -401,64 +401,79 @@ def add_bin_metrics(
             contig_to_aa_length=contig_to_aa_length,
             contamination_weight=contamination_weight,
             postProcessor=postProcessor,
-            threads=threads,  # Use all available threads in sequential mode
-        )
-    else:
-        # For parallel processing, use joblib
-
-        # Split bins into chunks for better parallelism
-        chunks_list = list(chunks(bins_list, chunk_size))
-        n_chunks = len(chunks_list)
-        n_jobs = min(threads, n_chunks)
-
-        logging.info(
-            f"Using {n_jobs} parallel jobs to process {n_chunks} chunks of bins"
+            threads=threads,
+            checkm2_batch_size=checkm2_batch_size,
         )
 
-        # Define a simple function to process a chunk
-        def process_chunk(chunk_bins):
-            # Initialize TensorFlow/Keras environment for this subprocess
-            _initialize_keras_environment()
-            
-            # Determine optimal thread count for this worker
-            # For best efficiency, we allocate a portion of total threads to each worker
-            # Math.ceil(total_threads / n_jobs) would be most aggressive
-            # But we use 1 thread per worker as the default to avoid oversubscription
-            worker_threads = max(1, threads // (2 * n_jobs))  # Conservative thread allocation
-            
-            # Create local processor instance
-            modelPostprocessing = get_modelPostprocessing()
-            local_postProcessor = modelPostprocessing.modelProcessor(worker_threads)
-            
-            # Process bins
-            return assess_bins_quality(
-                bins=chunk_bins,
-                contig_to_kegg_counter=contig_to_kegg_counter,
-                contig_to_cds_count=contig_to_cds_count,
-                contig_to_aa_counter=contig_to_aa_counter,
-                contig_to_aa_length=contig_to_aa_length,
-                contamination_weight=contamination_weight,
-                postProcessor=local_postProcessor,
-                threads=worker_threads,  # Use allocated threads in each worker
-            )        # Process chunks in parallel using joblib
-        with Progress(disable=disable_progress_bar) as progress:
-            task = progress.add_task("Assessing bin quality", total=len(bins_list))
-
-            # Use joblib for parallelization - it handles many complexities automatically
-            results = joblib.Parallel(n_jobs=n_jobs, verbose=0)(
-                joblib.delayed(process_chunk)(chunk) for chunk in chunks_list
+    # Use sequential processing if only 1 thread, few bins, or small dataset
+    # Use 2x batch size as threshold to avoid multiprocessing overhead for small datasets
+    sequential_threshold = checkm2_batch_size * 2
+    if threads == 1 or len(bins_list) <= sequential_threshold:
+        if len(bins_list) <= sequential_threshold:
+            logging.info(
+                f"Only {len(bins_list)} bins (≤ {sequential_threshold}). Using sequential processing to avoid multiprocessing overhead."
             )
+        return _process_sequential()
+    # For parallel processing, use joblib
 
-            # Combine results
-            all_bins = []
-            for chunk_result in results:
-                all_bins.extend(chunk_result)
-                progress.update(task, advance=len(chunk_result))
+    n_chunks = threads if len(bins_list) < 50_000 else threads * 2
+    n_jobs = min(threads, n_chunks)
+    # Use balanced chunking to distribute work evenly across available threads
+    chunks_list = balanced_chunks(bins_list, n_chunks)
 
-            return all_bins
+    logging.info(f"Using {n_jobs} parallel jobs to process {n_chunks} balanced chunks.")
+    for idx, chunk in enumerate(chunks_list):
+        logging.debug(f"Chunk {idx + 1}/{n_chunks} contains {len(chunk)} bins")
+
+    # Define a simple function to process a chunk
+    def process_chunk(chunk_bins):
+        # Initialize TensorFlow/Keras environment for this subprocess
+        _initialize_keras_environment()
+
+        # Determine optimal thread count for this worker
+        # For best efficiency, we allocate a portion of total threads to each worker
+        # Math.ceil(total_threads / n_jobs) would be most aggressive
+        # But we use 1 thread per worker as the default to avoid oversubscription
+        worker_threads = max(
+            1, threads // (2 * n_jobs)
+        )  # Conservative thread allocation
+
+        # Create local processor instance
+        modelPostprocessing = get_modelPostprocessing()
+        local_postProcessor = modelPostprocessing.modelProcessor(worker_threads)
+
+        # Process bins with nested chunking for memory management
+        return assess_bins_quality(
+            bins=chunk_bins,
+            contig_to_kegg_counter=contig_to_kegg_counter,
+            contig_to_cds_count=contig_to_cds_count,
+            contig_to_aa_counter=contig_to_aa_counter,
+            contig_to_aa_length=contig_to_aa_length,
+            contamination_weight=contamination_weight,
+            postProcessor=local_postProcessor,
+            threads=worker_threads,  # Use allocated threads in each worker
+            checkm2_batch_size=checkm2_batch_size,
+        )
+
+    # Process chunks in parallel using joblib
+    with Progress(disable=disable_progress_bar) as progress:
+        task = progress.add_task("Assessing bin quality", total=len(bins_list))
+
+        # Use joblib for parallelization - it handles many complexities automatically
+        results = joblib.Parallel(n_jobs=n_jobs, verbose=0)(
+            joblib.delayed(process_chunk)(chunk) for chunk in chunks_list
+        )
+
+        # Combine results
+        all_bins = []
+        for chunk_result in results:
+            all_bins.extend(chunk_result)
+            progress.update(task, advance=len(chunk_result))
+
+        return all_bins
 
 
-def chunks(iterable: Iterable, size: int) -> Iterator[Tuple]:
+def chunks(iterable, size: int) -> Iterator[Tuple]:
     """
     Generate adjacent chunks of data from an iterable.
 
@@ -470,6 +485,37 @@ def chunks(iterable: Iterable, size: int) -> Iterator[Tuple]:
     return iter(lambda: tuple(islice(it, size)), ())
 
 
+def balanced_chunks(items: List, num_chunks: int) -> List[List]:
+    """
+    Distribute items into balanced chunks with more even size distribution.
+
+    :param items: List of items to chunk.
+    :param num_chunks: Number of chunks to create.
+    :return: List of chunks with balanced sizes.
+    """
+    if num_chunks <= 0:
+        return [items]
+    if num_chunks >= len(items):
+        return [[item] for item in items]
+
+    # Calculate base size and remainder
+    base_size = len(items) // num_chunks
+    remainder = len(items) % num_chunks
+
+    chunks_list = []
+    start_idx = 0
+
+    for i in range(num_chunks):
+        # Some chunks get an extra item to distribute the remainder
+        chunk_size = base_size + (1 if i < remainder else 0)
+        chunk = items[start_idx : start_idx + chunk_size]
+        if chunk:  # Only add non-empty chunks
+            chunks_list.append(chunk)
+        start_idx += chunk_size
+
+    return chunks_list
+
+
 def assess_bins_quality(
     bins: Iterable[Bin],
     contig_to_kegg_counter: Dict,
@@ -477,6 +523,7 @@ def assess_bins_quality(
     contig_to_aa_counter: Dict,
     contig_to_aa_length: Dict,
     contamination_weight: float,
+    checkm2_batch_size: int,
     postProcessor=None,
     threads: int = 1,
 ):
@@ -494,10 +541,76 @@ def assess_bins_quality(
     :param contamination_weight: Weight for contamination assessment.
     :param postProcessor: A post-processor from checkm2
     :param threads: Number of threads for parallel processing (default is 1).
+    :param checkm2_batch_size: Maximum number of bins to process in a single CheckM2 call (default is 500).
     """
     if postProcessor is None:
         modelPostprocessing = get_modelPostprocessing()
         postProcessor = modelPostprocessing.modelProcessor(threads)
+
+    bins_list = list(bins)
+
+    # If we have fewer bins than the batch size, process them all at once
+    if len(bins_list) <= checkm2_batch_size:
+        return _assess_bins_quality_batch(
+            bins_list,
+            contig_to_kegg_counter,
+            contig_to_cds_count,
+            contig_to_aa_counter,
+            contig_to_aa_length,
+            contamination_weight,
+            postProcessor,
+            threads,
+        )
+
+    # Split bins into smaller batches for memory management
+    logging.debug(
+        f"Splitting {len(bins_list)} bins into batches of {checkm2_batch_size} for CheckM2 processing"
+    )
+
+    all_processed_bins = []
+    batch_chunks = list(chunks(bins_list, checkm2_batch_size))
+
+    for i, batch_bins in enumerate(batch_chunks):
+        logging.debug(
+            f"Processing CheckM2 batch {i+1}/{len(batch_chunks)} with {len(batch_bins)} bins"
+        )
+
+        # Process this batch
+        processed_batch = _assess_bins_quality_batch(
+            batch_bins,
+            contig_to_kegg_counter,
+            contig_to_cds_count,
+            contig_to_aa_counter,
+            contig_to_aa_length,
+            contamination_weight,
+            postProcessor,
+            threads,
+        )
+
+        all_processed_bins.extend(processed_batch)
+
+        # Force garbage collection between batches to free memory
+        gc.collect()
+
+    return all_processed_bins
+
+
+def _assess_bins_quality_batch(
+    bins: List[Bin],
+    contig_to_kegg_counter: Dict,
+    contig_to_cds_count: Dict,
+    contig_to_aa_counter: Dict,
+    contig_to_aa_length: Dict,
+    contamination_weight: float,
+    postProcessor,
+    threads: int,
+):
+    """
+    Assess the quality of a batch of bins (internal function).
+
+    This function processes a single batch of bins through CheckM2.
+    It's called by assess_bins_quality for each batch when memory management is needed.
+    """
 
     metadata_df = get_bins_metadata_df(
         bins, contig_to_cds_count, contig_to_aa_counter, contig_to_aa_length

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from rich.progress import Progress
 
 
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from binette.bin_manager import Bin
 from checkm2 import keggData
 
@@ -339,8 +340,13 @@ def add_bin_metrics(
     contig_to_aa_counter = contig_info["contig_to_aa_counter"]
     contig_to_aa_length = contig_info["contig_to_aa_length"]
 
+    parallel_chunks = threads
+    model_threads = 1
     logging.info(f"Assessing bin quality for {len(bins)} bins.")
-    assess_bins_quality_by_chunk(
+    logging.debug(
+        f"Using chunk size of {chunk_size} and parallel chunks of {parallel_chunks}."
+    )
+    bins = assess_bins_quality_by_chunk(
         bins,
         contig_to_kegg_counter,
         contig_to_cds_count,
@@ -349,8 +355,11 @@ def add_bin_metrics(
         contamination_weight,
         postProcessor,
         chunk_size=chunk_size,
+        parallel_chunks=threads,
+        threads=model_threads,
         disable_progress_bar=disable_progress_bar,
     )
+
     return bins
 
 
@@ -366,7 +375,104 @@ def chunks(iterable: Iterable, size: int) -> Iterator[Tuple]:
     return iter(lambda: tuple(islice(it, size)), ())
 
 
+def _process_chunk(
+    chunk_bins,
+    contig_to_kegg_counter,
+    contig_to_cds_count,
+    contig_to_aa_counter,
+    contig_to_aa_length,
+    contamination_weight,
+    threads,
+):
+    """
+    Worker function for processing a chunk of bins.
+    Each worker creates its own modelProcessor instance.
+    """
+    # We do NOT pass postProcessor here to avoid cross-process object sharing
+    return assess_bins_quality(
+        bins=chunk_bins,
+        contig_to_kegg_counter=contig_to_kegg_counter,
+        contig_to_cds_count=contig_to_cds_count,
+        contig_to_aa_counter=contig_to_aa_counter,
+        contig_to_aa_length=contig_to_aa_length,
+        contamination_weight=contamination_weight,
+        postProcessor=None,
+        threads=threads,
+    )
+
+
 def assess_bins_quality_by_chunk(
+    bins,
+    contig_to_kegg_counter,
+    contig_to_cds_count,
+    contig_to_aa_counter,
+    contig_to_aa_length,
+    contamination_weight,
+    postProcessor=None,
+    threads: int = 1,
+    chunk_size: int = 2500,
+    parallel_chunks: int = 1,
+    disable_progress_bar: bool = False,
+):
+    bins = list(bins)
+    chunks_list = [chunk for chunk in chunks(bins, chunk_size)]
+
+    logging.info(
+        f"Assessing quality of {len(bins)} bins in {len(chunks_list)} chunks "
+        f"(parallel_chunks={parallel_chunks}, threads={threads})"
+    )
+
+    bins_scored = []
+
+    # Cap parallel_chunks to number of chunks
+    parallel_chunks = min(parallel_chunks, len(chunks_list))
+
+    with Progress(disable=disable_progress_bar) as progress:
+        task = progress.add_task("Assessing bin quality", total=len(bins))
+
+        if parallel_chunks > 1:
+            # Multiprocessing mode
+            with ProcessPoolExecutor(max_workers=parallel_chunks) as executor:
+                futures = {
+                    executor.submit(
+                        _process_chunk,
+                        chunk_bins,
+                        contig_to_kegg_counter,
+                        contig_to_cds_count,
+                        contig_to_aa_counter,
+                        contig_to_aa_length,
+                        contamination_weight,
+                        threads,
+                    ): chunk_bins
+                    for chunk_bins in chunks_list
+                }
+
+                for future in as_completed(futures):
+                    chunk_bins_scored = future.result()
+                    bins_scored.extend(chunk_bins_scored)
+                    progress.update(task, advance=len(chunk_bins_scored))
+
+        else:
+            # Sequential mode
+            for i, chunk_bins in enumerate(chunks_list):
+                logging.debug(f"chunk {i}: assessing quality of {len(chunk_bins)} bins")
+                chunk_bins_scored = assess_bins_quality(
+                    bins=chunk_bins,
+                    contig_to_kegg_counter=contig_to_kegg_counter,
+                    contig_to_cds_count=contig_to_cds_count,
+                    contig_to_aa_counter=contig_to_aa_counter,
+                    contig_to_aa_length=contig_to_aa_length,
+                    contamination_weight=contamination_weight,
+                    postProcessor=postProcessor,
+                    threads=threads,
+                )
+                bins_scored.extend(chunk_bins_scored)
+                progress.update(task, advance=len(chunk_bins_scored))
+
+    return bins_scored
+
+
+def assess_bins_quality_by_chunk_old(
     bins: Iterable[Bin],
     contig_to_kegg_counter: Dict,
     contig_to_cds_count: Dict,

--- a/binette/bin_quality.py
+++ b/binette/bin_quality.py
@@ -368,8 +368,9 @@ def add_bin_metrics(
                     If threads>1, processing is parallelized across multiple processes.
                     The number of parallel workers will be approximately equal to threads.
     :param checkm2_batch_size: Maximum number of bins to send to CheckM2 at once within each process
-                              to control memory usage (default is 500). This creates sub-batches
+                              to control memory usage (default is 600). This creates sub-batches
                               within each worker to manage CheckM2's memory consumption.
+                              Can be overridden by BINETTE_CHECKM2_BATCH_SIZE env variable.
     :param disable_progress_bar: Disable the progress bar if True.
 
     :return: List of processed bin objects with quality metrics added.
@@ -377,6 +378,19 @@ def add_bin_metrics(
     if not bins:
         logging.warning("No bins provided for quality assessment")
         return []
+
+    # Override checkm2_batch_size from environment variable if set
+    env_batch_size = os.environ.get("BINETTE_CHECKM2_BATCH_SIZE")
+    if env_batch_size:
+        try:
+            checkm2_batch_size = int(env_batch_size)
+            logging.info(
+                f"Using CheckM2 batch size from environment: {checkm2_batch_size}"
+            )
+        except ValueError:
+            logging.warning(
+                f"Invalid BINETTE_CHECKM2_BATCH_SIZE value: {env_batch_size}, using default: {checkm2_batch_size}"
+            )
 
     bins_list = list(bins)
     logging.info(
@@ -416,14 +430,47 @@ def add_bin_metrics(
         return _process_sequential()
     # For parallel processing, use joblib
 
-    n_chunks = threads if len(bins_list) < 50_000 else threads * 2
+    # Get chunk multiplier from environment variable for testing
+    env_chunk_multiplier = os.environ.get("BINETTE_CHUNK_MULTIPLIER")
+    if env_chunk_multiplier:
+        try:
+            chunk_multiplier = float(env_chunk_multiplier)
+            logging.info(f"Using chunk multiplier from environment: {chunk_multiplier}")
+        except ValueError:
+            logging.warning(
+                f"Invalid BINETTE_CHUNK_MULTIPLIER value: {env_chunk_multiplier}, using default logic"
+            )
+            chunk_multiplier = None
+    else:
+        chunk_multiplier = None
+
+    # Calculate number of chunks based on environment variable or default logic
+    if chunk_multiplier is not None:
+        # Use environment-specified multiplier for testing
+        n_chunks = max(1, int(threads * chunk_multiplier))
+        logging.info(
+            f"Using {chunk_multiplier}x chunk multiplier: {threads} threads → {n_chunks} chunks"
+        )
+    else:
+        # Use default logic (simple threshold-based)
+        n_chunks = threads if len(bins_list) < 50_000 else threads * 2
+        strategy = "static" if len(bins_list) < 50_000 else "2x load balancing"
+        logging.info(
+            f"Using default chunking strategy ({strategy}): {threads} threads → {n_chunks} chunks"
+        )
+
     n_jobs = min(threads, n_chunks)
     # Use balanced chunking to distribute work evenly across available threads
     chunks_list = balanced_chunks(bins_list, n_chunks)
 
-    logging.info(f"Using {n_jobs} parallel jobs to process {n_chunks} balanced chunks.")
+    logging.info(
+        f"Created {len(chunks_list)} balanced chunks for {n_jobs} parallel jobs"
+    )
+    logging.info(
+        f"Configuration: {len(bins_list)} bins, {threads} threads, {n_chunks} chunks, batch_size={checkm2_batch_size}"
+    )
     for idx, chunk in enumerate(chunks_list):
-        logging.debug(f"Chunk {idx + 1}/{n_chunks} contains {len(chunk)} bins")
+        logging.debug(f"Chunk {idx + 1}/{len(chunks_list)} contains {len(chunk)} bins")
 
     # Define a simple function to process a chunk
     def process_chunk(chunk_bins):

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -2,11 +2,11 @@ import concurrent.futures as cf
 import multiprocessing.pool
 import logging
 from collections import Counter, defaultdict
-from typing import Dict, List, Iterator, Tuple, Any, Union, Set
+from typing import Dict, List, Iterator, Tuple, Any, Union
 
 import pyfastx
 import pyrodigal
-from tqdm import tqdm
+
 from pathlib import Path
 import gzip
 
@@ -157,14 +157,13 @@ def get_contig_cds_metadata_flat(
     }
 
     contig_to_aa_counter = {
-        contig: get_aa_composition(genes)
-        for contig, genes in tqdm(contig_to_genes.items(), unit="contig")
+        contig: get_aa_composition(genes) for contig, genes in contig_to_genes.items()
     }
     logging.info("Calculating amino acid composition.")
 
     contig_to_aa_length = {
         contig: sum(counter.values())
-        for contig, counter in tqdm(contig_to_aa_counter.items(), unit="contig")
+        for contig, counter in contig_to_aa_counter.items()
     }
     logging.info("Calculating total amino acid length.")
 
@@ -188,18 +187,17 @@ def get_contig_cds_metadata(
     contig_to_future = {}
     logging.info(f"Collecting contig amino acid composition using {threads} threads.")
     with cf.ProcessPoolExecutor(max_workers=threads) as tpe:
-        for contig, genes in tqdm(contig_to_genes.items()):
+        for contig, genes in contig_to_genes.items():
             contig_to_future[contig] = tpe.submit(get_aa_composition, genes)
 
     contig_to_aa_counter = {
-        contig: future.result()
-        for contig, future in tqdm(contig_to_future.items(), unit="contig")
+        contig: future.result() for contig, future in contig_to_future.items()
     }
     logging.info("Calculating amino acid composition in parallel.")
 
     contig_to_aa_length = {
         contig: sum(counter.values())
-        for contig, counter in tqdm(contig_to_aa_counter.items(), unit="contig")
+        for contig, counter in contig_to_aa_counter.items()
     }
     logging.info("Calculating total amino acid length in parallel.")
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -675,6 +675,7 @@ def run_binette(
         contamination_weight=contamination_weight,
         threads=threads,
         disable_progress_bar=not progress,
+        chunk_size=20000,
     )
     contig_key_to_new_bin = {b.contigs_key: b for b in new_bins}
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -35,50 +35,6 @@ logger = logging.getLogger(__name__)
 err_console = Console(stderr=True)
 
 
-def preprocess_args():
-    """
-    Typer doesn't support whitespace-separated multi-value options.
-
-    We preprocess the sysargv so that:
-    - python3 app.py some_command --filters filter1 filter2 filter3 --environments env1 env2 env3
-
-    becomes:
-    - python3 app.py some_command --filters filter1 --filters filter2 --filters filter3 --environments env1 --environments env2 --environments env3
-
-    //!\\ DOWNSIDE: options should always be after arguments in the CLI command //!\\
-    """
-
-    logger.debug(f"Initial CLI command is: {sys.argv}")
-
-    # get main cmd
-    final_cmd = []
-    for idx, arg in enumerate(sys.argv):
-        if any(arg.startswith(_) for _ in ["-", "--"]):
-            break
-        else:
-            final_cmd.append(arg)
-    logger.debug(f"Main command is: {final_cmd}")
-
-    # get options and their values
-    for idx, arg in enumerate(sys.argv):
-        if any(arg.startswith(_) for _ in ["-", "--"]):
-            opt_values = []
-            for value in sys.argv[idx + 1 :]:
-                if any(value.startswith(_) for _ in ["-", "--"]):
-                    break
-                else:
-                    opt_values.append(value)
-
-            if len(opt_values) >= 1:
-                [final_cmd.extend([arg, opt_value]) for opt_value in opt_values]
-            else:
-                final_cmd.append(arg)
-
-    # replace by reformatted
-    logger.debug(f"Final command is: {final_cmd}")
-    sys.argv = final_cmd
-
-
 def version_callback(
     value: bool,
     ctx: typer.Context,
@@ -112,6 +68,49 @@ def verbose_callback(
     logging.info(
         f'command line: {" ".join(sys.argv)}',
     )
+
+
+def preprocess_args():
+    """
+    Typer doesn't support whitespace-separated multi-value options.
+
+    We preprocess the sysargv so that:
+    - python3 app.py some_command --filters filter1 filter2 filter3 --environments env1 env2 env3
+
+    becomes:
+    - python3 app.py some_command --filters filter1 --filters filter2 --filters filter3 --environments env1 --environments env2 --environments env3
+
+    """
+
+    logger.debug(f"Initial CLI command is: {sys.argv}")
+
+    # get main cmd
+    final_cmd = []
+    for idx, arg in enumerate(sys.argv):
+        if any(arg.startswith(_) for _ in ["-", "--"]):
+            break
+        else:
+            final_cmd.append(arg)
+    logger.debug(f"Main command is: {final_cmd}")
+
+    # get options and their values
+    for idx, arg in enumerate(sys.argv):
+        if any(arg.startswith(_) for _ in ["-", "--"]):
+            opt_values = []
+            for value in sys.argv[idx + 1 :]:
+                if any(value.startswith(_) for _ in ["-", "--"]):
+                    break
+                else:
+                    opt_values.append(value)
+
+            if len(opt_values) >= 1:
+                [final_cmd.extend([arg, opt_value]) for opt_value in opt_values]
+            else:
+                final_cmd.append(arg)
+
+    # replace by reformatted
+    logger.debug(f"Final command is: {final_cmd}")
+    sys.argv = final_cmd
 
 
 # Create the Typer app with no args help enabled and rich formatting
@@ -365,7 +364,7 @@ def log_selected_bin_info(
     help=f"Binette {binette.__version__}: fast and accurate binning refinement tool to constructs high quality MAGs from the output of multiple binning tools.",
     no_args_is_help=True,
 )
-def main(
+def run_binette(
     # Input arguments - Mutually exclusive group (handled in code)
     bin_dirs: Annotated[
         Optional[List[Path]],
@@ -707,8 +706,7 @@ def main(
     return 0
 
 
-def main_main():
-    """Main function to run the application."""
+def main():
     preprocess_args()
 
     app()

--- a/binette/main.py
+++ b/binette/main.py
@@ -537,7 +537,14 @@ def run_binette(
     progress: Annotated[
         bool,
         typer.Option(
-            help="Show progress bar while fetching pangenomes (disable with --no_progress).",
+            help="Show progress bar while fetching pangenomes (disable with --no-progress).",
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = True,
+    write_fasta_bins: Annotated[
+        bool,
+        typer.Option(
+            help="Write final selected bins as FASTA files (disable with --no-write-fasta-bins).",
             rich_help_panel="Output and Runtime Control",
         ),
     ] = True,
@@ -556,8 +563,6 @@ def run_binette(
     # High quality threshold used just to log number of high quality bins.
     hq_max_conta = 5
     hq_min_completeness = 90
-
-    write_final_fasta_bins = True
 
     # Temporary files #
     out_tmp_dir: Path = outdir / "temporary_files"
@@ -693,7 +698,7 @@ def run_binette(
     logging.info(f"Writing selected bins in {final_bin_report}")
     io.write_bin_info(selected_bins, output=final_bin_report)
 
-    if write_final_fasta_bins:
+    if write_fasta_bins:
         io.write_bins_fasta(
             selected_bins,
             contigs,

--- a/binette/main.py
+++ b/binette/main.py
@@ -2,17 +2,23 @@
 """
 Module      : Main
 Description : The main entry point for the program.
-Copyright   : (c) Jean Mainguy, 28 nov. 2022 
-License     : MIT
+Copyright   : (c) Jean Mainguy, 28 nov. 2022
+License     : GPL-3.0
 Maintainer  : Jean Mainguy
 Portability : POSIX
 """
 
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Action, Namespace
-
 import sys
 import logging
 import os
+import typer
+from typing import List, Dict, Optional, Set, Tuple, Annotated
+from pathlib import Path
+import pyfastx
+
+from rich.logging import RichHandler
+from rich.console import Console
+
 
 import binette
 from binette import (
@@ -23,238 +29,99 @@ from binette import (
     bin_manager,
     io_manager as io,
 )
-from typing import List, Dict, Optional, Set, Tuple, Union, Sequence, Any
-from pathlib import Path
-import pyfastx
 
 
-def init_logging(verbose, debug):
-    """Initialise logging."""
-    if debug:
-        level = logging.DEBUG
-    elif verbose:
-        level = logging.INFO
-    else:
-        level = logging.WARNING
+logger = logging.getLogger(__name__)
+err_console = Console(stderr=True)
 
+
+def preprocess_args():
+    """
+    Typer doesn't support whitespace-separated multi-value options.
+
+    We preprocess the sysargv so that:
+    - python3 app.py some_command --filters filter1 filter2 filter3 --environments env1 env2 env3
+
+    becomes:
+    - python3 app.py some_command --filters filter1 --filters filter2 --filters filter3 --environments env1 --environments env2 --environments env3
+
+    //!\\ DOWNSIDE: options should always be after arguments in the CLI command //!\\
+    """
+
+    logger.debug(f"Initial CLI command is: {sys.argv}")
+
+    # get main cmd
+    final_cmd = []
+    for idx, arg in enumerate(sys.argv):
+        if any(arg.startswith(_) for _ in ["-", "--"]):
+            break
+        else:
+            final_cmd.append(arg)
+    logger.debug(f"Main command is: {final_cmd}")
+
+    # get options and their values
+    for idx, arg in enumerate(sys.argv):
+        if any(arg.startswith(_) for _ in ["-", "--"]):
+            opt_values = []
+            for value in sys.argv[idx + 1 :]:
+                if any(value.startswith(_) for _ in ["-", "--"]):
+                    break
+                else:
+                    opt_values.append(value)
+
+            if len(opt_values) >= 1:
+                [final_cmd.extend([arg, opt_value]) for opt_value in opt_values]
+            else:
+                final_cmd.append(arg)
+
+    # replace by reformatted
+    logger.debug(f"Final command is: {final_cmd}")
+    sys.argv = final_cmd
+
+
+def version_callback(
+    value: bool,
+    ctx: typer.Context,
+):
+    """Prints the version and exits if --version is passed."""
+    if ctx.resilient_parsing:
+        return
+
+    if value:
+        typer.echo(f"Binette {binette.__version__}")
+        raise typer.Exit()
+
+
+def verbose_callback(
+    verbose: bool,
+):
+    """Sets the logging level to DEBUG if --verbose is passed."""
+    lvl = logging.INFO
+
+    if verbose:
+        lvl = logging.DEBUG
+
+    # Set up logging
     logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s - %(message)s",
-        datefmt="[%Y-%m-%d %H:%M:%S]",
+        level=lvl,
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(console=err_console)],
     )
-
     logging.info("Program started")
     logging.info(
         f'command line: {" ".join(sys.argv)}',
     )
 
 
-class UniqueStore(Action):
-    """
-    Custom argparse action to ensure an argument is provided only once.
-    """
-
-    def __call__(
-        self,
-        parser: ArgumentParser,
-        namespace: Namespace,
-        values: Union[str, Sequence[Any], None],
-        option_string: Optional[str] = None,
-    ) -> None:
-        """
-        Ensures the argument is only used once. Raises an error if the argument appears multiple times.
-
-        :param parser: The argparse parser instance.
-        :param namespace: The namespace object that will contain the parsed arguments.
-        :param values: The value associated with the argument.
-        :param option_string: The option string that was used to invoke this action.
-        """
-        # Check if the argument has already been set
-        if getattr(namespace, self.dest, self.default) is not self.default:
-            parser.error(
-                f"Error: The argument {option_string} can only be specified once."
-            )
-
-        # Set the argument value
-        setattr(namespace, self.dest, values)
-
-
-def is_valid_file(parser: ArgumentParser, arg: str) -> Path:
-    """
-    Validates that the provided input file exists.
-
-    :param parser: The ArgumentParser instance handling command-line arguments.
-    :param arg: The path to the file provided as an argument.
-    :return: A Path object representing the valid file.
-    """
-    path_arg = Path(arg)
-
-    # Check if the file exists at the provided path
-    if not path_arg.exists():
-        parser.error(f"Error: The specified file '{arg}' does not exist.")
-
-    return path_arg
-
-
-def parse_arguments(args):
-    """Parse script arguments."""
-
-    parser = ArgumentParser(
-        description=f"Binette version={binette.__version__}",
-        formatter_class=ArgumentDefaultsHelpFormatter,
-    )
-
-    # ------------------------
-    # Input arguments
-    # ------------------------
-    input_group = parser.add_argument_group("Input Arguments")
-    input_arg = input_group.add_mutually_exclusive_group(required=True)
-
-    input_arg.add_argument(
-        "-d",
-        "--bin-dirs",
-        nargs="+",
-        type=lambda x: is_valid_file(parser, x),
-        action=UniqueStore,
-        help="List of bin folders containing each bin in a fasta file.",
-    )
-
-    input_arg.add_argument(
-        "-b",
-        "--contig2bin-tables",
-        nargs="+",
-        action=UniqueStore,
-        type=lambda x: is_valid_file(parser, x),
-        help="List of contig2bin tables with two columns separated "
-        "by a tabulation: contig, bin.",
-    )
-
-    input_group.add_argument(
-        "-c",
-        "--contigs",
-        required=True,
-        type=lambda x: is_valid_file(parser, x),
-        help="Contigs in FASTA format.",
-    )
-
-    input_group.add_argument(
-        "-p",
-        "--proteins",
-        type=lambda x: is_valid_file(parser, x),
-        help="FASTA file of predicted proteins in Prodigal format (>contigID_geneID). "
-        "Skips the gene prediction step if provided.",
-    )
-
-    # ------------------------
-    # Output & runtime control
-    # ------------------------
-    runtime_group = parser.add_argument_group("Output and Runtime Control")
-
-    runtime_group.add_argument(
-        "-o", "--outdir", default=Path("results"), type=Path, help="Output directory."
-    )
-    runtime_group.add_argument(
-        "--prefix",
-        type=str,
-        default="binette",
-        help="Prefix to add to final bin names (e.g. '--prefix sample1_' will produce 'sample1_bin1.fa', 'sample1_bin2.fa').",
-    )
-
-    runtime_group.add_argument(
-        "-t", "--threads", default=1, type=int, help="Number of threads to use."
-    )
-
-    runtime_group.add_argument(
-        "--resume",
-        action="store_true",
-        help="Resume mode: reuse existing temporary files if possible.",
-    )
-
-    runtime_group.add_argument(
-        "-v", "--verbose", help="Increase output verbosity.", action="store_true"
-    )
-
-    runtime_group.add_argument(
-        "--debug", help="Activate debug mode.", action="store_true"
-    )
-
-    runtime_group.add_argument(
-        "--version", action="version", version=binette.__version__
-    )
-
-    # ------------------------
-    # Bin filtering & scoring
-    # ------------------------
-    filter_group = parser.add_argument_group("Bin Filtering and Scoring")
-
-    filter_group.add_argument(
-        "--min-completeness",
-        "--min_completeness",
-        default=40,
-        type=int,
-        help="Minimum completeness required for intermediate bin creation and final bin selection.",
-    )
-
-    filter_group.add_argument(
-        "--max-contamination",
-        "--max_contamination",
-        default=10,
-        type=int,
-        help="Maximum contamination allowed for intermediate bin creation and final bin selection.",
-    )
-
-    filter_group.add_argument(
-        "--min-length",
-        default=200_000,
-        type=int,
-        help="Minimum length (bp) required for intermediate bin creation and final bin selection.",
-    )
-
-    filter_group.add_argument(
-        "--max-length",
-        default=10_000_000,
-        type=int,
-        help="Maximum length (bp) allowed for intermediate bin creation and final bin selection.",
-    )
-
-    filter_group.add_argument(
-        "-w",
-        "--contamination-weight",
-        "--contamination_weight",
-        default=2,
-        type=float,
-        help="Bins are scored as: completeness - weight * contamination. "
-        "A lower weight favors completeness over low contamination.",
-    )
-
-    # ------------------------
-    # Advanced options
-    # ------------------------
-    advanced_group = parser.add_argument_group("Advanced Options")
-
-    advanced_group.add_argument(
-        "-e",
-        "--fasta-extensions",
-        "--fasta_extensions",
-        nargs="+",
-        default={".fasta", ".fa", ".fna"},
-        type=str,
-        help="FASTA file extensions to search for in bin directories (used with --bin-dirs).",
-    )
-
-    advanced_group.add_argument(
-        "--checkm2-db",
-        "--checkm2_db",
-        type=Path,
-        help="Path to CheckM2 diamond database. "
-        "By default the database set via <checkm2 database> is used.",
-    )
-
-    advanced_group.add_argument(
-        "--low-mem", help="Enable low-memory mode for Diamond.", action="store_true"
-    )
-
-    return parser.parse_args(args)
+# Create the Typer app with no args help enabled and rich formatting
+app = typer.Typer(
+    name="binette",
+    help=f"Binette: binning refinement tool to constructs high quality MAGs. Version: {binette.__version__}",
+    add_completion=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    rich_markup_mode="rich",
+)
 
 
 def parse_input_files(
@@ -494,14 +361,198 @@ def log_selected_bin_info(
     )
 
 
-def main():
-    "Orchestrate the execution of the program"
+@app.command(
+    help=f"Binette {binette.__version__}: fast and accurate binning refinement tool to constructs high quality MAGs from the output of multiple binning tools.",
+    no_args_is_help=True,
+)
+def main(
+    # Input arguments - Mutually exclusive group (handled in code)
+    bin_dirs: Annotated[
+        Optional[List[Path]],
+        typer.Option(
+            "--bin-dirs",
+            "-d",
+            help="List of bin folders containing each bin in a fasta file.",
+            # callback=lambda x: [is_valid_file(str(p)) for p in x] if x else None,
+            exists=True,
+            rich_help_panel="Input Arguments",
+        ),
+    ] = None,
+    contig2bin_tables: Annotated[
+        Optional[List[Path]],
+        typer.Option(
+            "--contig2bin-tables",
+            "-b",
+            help="List of contig2bin tables with two columns: contig, bin.",
+            exists=True,
+            rich_help_panel="Input Arguments",
+        ),
+    ] = None,
+    contigs: Annotated[
+        Path,
+        typer.Option(
+            "--contigs",
+            "-c",
+            help="Contigs in FASTA format.",
+            exists=True,
+            rich_help_panel="Input Arguments",
+        ),
+    ] = ...,  # Required
+    proteins: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--proteins",
+            "-p",
+            help="FASTA file of predicted proteins in Prodigal format (>contigID_geneID). Skips the gene prediction step if provided.",
+            exists=True,
+            rich_help_panel="Input Arguments",
+        ),
+    ] = None,
+    # Output & runtime control
+    outdir: Annotated[
+        Path,
+        typer.Option(
+            "--outdir",
+            "-o",
+            help="Output directory.",
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = Path("results"),
+    prefix: Annotated[
+        str,
+        typer.Option(
+            "--prefix",
+            help="Prefix to add to final bin names (e.g. '--prefix sample1' will produce 'sample1_bin1.fa', 'sample1_bin2.fa').",
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = "binette",
+    threads: Annotated[
+        int,
+        typer.Option(
+            "--threads",
+            "-t",
+            help="Number of threads to use.",
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = 1,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Enable verbose logging.",
+            callback=verbose_callback,
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = False,
+    debug: Annotated[
+        bool,
+        typer.Option(
+            help="Activate debug mode.",
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = False,
+    # Bin filtering & scoring
+    min_completeness: Annotated[
+        int,
+        typer.Option(
+            "--min-completeness",
+            help="Minimum completeness required for intermediate bin creation and final bin selection.",
+            rich_help_panel="Bin Filtering and Scoring",
+        ),
+    ] = 40,
+    max_contamination: Annotated[
+        int,
+        typer.Option(
+            "--max-contamination",
+            help="Maximum contamination allowed for intermediate bin creation and final bin selection.",
+            rich_help_panel="Bin Filtering and Scoring",
+        ),
+    ] = 10,
+    min_length: Annotated[
+        int,
+        typer.Option(
+            "--min-length",
+            help="Minimum length (bp) required for intermediate bin creation and final bin selection.",
+            rich_help_panel="Bin Filtering and Scoring",
+        ),
+    ] = 200_000,
+    max_length: Annotated[
+        int,
+        typer.Option(
+            "--max-length",
+            help="Maximum length (bp) allowed for intermediate bin creation and final bin selection.",
+            rich_help_panel="Bin Filtering and Scoring",
+        ),
+    ] = 10_000_000,
+    contamination_weight: Annotated[
+        float,
+        typer.Option(
+            "--contamination-weight",
+            "-w",
+            help="Bins are scored as: completeness - weight * contamination. A lower weight favors completeness over low contamination.",
+            rich_help_panel="Bin Filtering and Scoring",
+        ),
+    ] = 2.0,
+    # Advanced options
+    fasta_extensions: Annotated[
+        List[str],
+        typer.Option(
+            "--fasta-extensions",
+            "-e",
+            help="FASTA file extensions to search for in bin directories (used with --bin-dirs).",
+            rich_help_panel="Advanced Options",
+        ),
+    ] = [".fasta", ".fa", ".fna"],
+    checkm2_db: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--checkm2-db",
+            help="Path to CheckM2 diamond database. By default the database set via <checkm2 database> is used.",
+            rich_help_panel="Advanced Options",
+        ),
+    ] = None,
+    low_mem: Annotated[
+        bool,
+        typer.Option(
+            "--low-mem",
+            help="Enable low-memory mode for Diamond.",
+            rich_help_panel="Advanced Options",
+        ),
+    ] = False,
+    resume: Annotated[
+        bool,
+        typer.Option(
+            help="Resume mode: reuse existing temporary files if possible.",
+            rich_help_panel="Advanced Options",
+        ),
+    ] = False,
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            help="Show version and exit.",
+            callback=version_callback,
+        ),
+    ] = None,
+    progress: Annotated[
+        bool,
+        typer.Option(
+            help="Show progress bar while fetching pangenomes (disable with --no-progress).",
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = True,
+) -> int:
+    """Orchestrate the execution of the program"""
 
-    args = parse_arguments(
-        sys.argv[1:]
-    )  # sys.argv is passed in order to be able to test the function parse_arguments
-
-    init_logging(args.verbose, args.debug)
+    # Validate that exactly one of bin_dirs or contig2bin_tables is provided
+    if (bin_dirs is None and contig2bin_tables is None) or (
+        bin_dirs is not None and contig2bin_tables is not None
+    ):
+        typer.echo(
+            "Error: Either --bin-dirs or --contig2bin-tables must be provided, but not both."
+        )
+        raise typer.Exit(code=1)
 
     # High quality threshold used just to log number of high quality bins.
     hq_max_conta = 5
@@ -510,7 +561,7 @@ def main():
     write_final_fasta_bins = True
 
     # Temporary files #
-    out_tmp_dir: Path = args.outdir / "temporary_files"
+    out_tmp_dir: Path = outdir / "temporary_files"
     os.makedirs(out_tmp_dir, exist_ok=True)
 
     use_existing_protein_file = False
@@ -520,10 +571,10 @@ def main():
     diamond_result_file = out_tmp_dir / "diamond_result.tsv.gz"
 
     # Output files #
-    final_bin_report: Path = args.outdir / "final_bins_quality_reports.tsv"
-    original_bin_report_dir: Path = args.outdir / "input_bins_quality_reports"
+    final_bin_report: Path = outdir / "final_bins_quality_reports.tsv"
+    original_bin_report_dir: Path = outdir / "input_bins_quality_reports"
 
-    if args.resume:
+    if resume:
         io.check_resume_file(faa_file, diamond_result_file)
         use_existing_protein_file = True
 
@@ -533,40 +584,40 @@ def main():
         contig_to_length,
         contig_to_index,
     ) = parse_input_files(
-        args.bin_dirs,
-        args.contig2bin_tables,
-        args.contigs,
-        fasta_extensions=set(args.fasta_extensions),
+        bin_dirs,
+        contig2bin_tables,
+        contigs,
+        fasta_extensions=set(fasta_extensions),
     )
 
-    if args.debug:
-        index_to_contig_file = args.outdir / "index_to_contig.tsv"
+    if debug:
+        index_to_contig_file = outdir / "index_to_contig.tsv"
         logging.info(f"Writing index to contig mapping in {index_to_contig_file}")
         with open(index_to_contig_file, "w") as flout:
             flout.write("\n".join((f"{i}\t{c}" for i, c in enumerate(contigs_in_bins))))
 
     original_bins = list(contig_key_to_original_bin.values())
 
-    if args.proteins and not args.resume:
-        logging.info(f"Using the provided protein sequences file: {args.proteins}")
+    if proteins and not resume:
+        logging.info(f"Using the provided protein sequences file: {proteins}")
         use_existing_protein_file = True
 
         cds.filter_faa_file(
             contigs_in_bins,
-            input_faa_file=args.proteins,
+            input_faa_file=proteins,
             filtered_faa_file=faa_file,
         )
 
     contig_name_to_kegg_counter, contig_name_to_genes = manage_protein_alignement(
         faa_file=faa_file,
-        contigs_fasta=args.contigs,
+        contigs_fasta=contigs,
         contigs_in_bins=contigs_in_bins,
         diamond_result_file=diamond_result_file,
-        checkm2_db=args.checkm2_db,
-        threads=args.threads,
+        checkm2_db=checkm2_db,
+        threads=threads,
         use_existing_protein_file=use_existing_protein_file,
-        resume_diamond=args.resume,
-        low_mem=args.low_mem,
+        resume_diamond=resume,
+        low_mem=low_mem,
     )
 
     contig_to_kegg_counter = contig_manager.apply_contig_index(
@@ -578,14 +629,14 @@ def main():
 
     # Extract cds metadata ##
     logging.info("Compute cds metadata.")
-    contig_metadat = cds.get_contig_cds_metadata(contig_to_genes, args.threads)
+    contig_metadat = cds.get_contig_cds_metadata(contig_to_genes, threads)
 
     contig_metadat["contig_to_kegg_counter"] = contig_to_kegg_counter
     contig_metadat["contig_to_length"] = contig_to_length
 
     logging.info("Add size and assess quality of input bins")
     bin_quality.add_bin_metrics(
-        original_bins, contig_metadat, args.contamination_weight, args.threads
+        original_bins, contig_metadat, contamination_weight, threads
     )
     bin_quality.add_bin_size_and_N50(original_bins, contig_to_length)
 
@@ -601,10 +652,10 @@ def main():
     contig_key_to_new_bin = bin_manager.create_intermediate_bins(
         contig_key_to_original_bin,
         contig_lengths=contig_lengths,
-        min_comp=args.min_completeness,
-        max_conta=args.max_contamination,
-        min_len=args.min_length,
-        max_len=args.max_length,
+        min_comp=min_completeness,
+        max_conta=max_contamination,
+        min_len=min_length,
+        max_len=max_length,
     )
 
     logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")
@@ -612,16 +663,16 @@ def main():
     bin_quality.add_bin_metrics(
         bins=contig_key_to_new_bin.values(),
         contig_info=contig_metadat,
-        contamination_weight=args.contamination_weight,
-        threads=args.threads,
+        contamination_weight=contamination_weight,
+        threads=threads,
     )
 
     contig_key_to_all_bin = contig_key_to_original_bin | contig_key_to_new_bin
 
     bin_quality.add_bin_size_and_N50(contig_key_to_all_bin.values(), contig_to_length)
 
-    if args.debug:
-        all_bin_compo_file = args.outdir / "all_bins_quality_reports.tsv"
+    if debug:
+        all_bin_compo_file = outdir / "all_bins_quality_reports.tsv"
         logging.info(f"Writing all bins in {all_bin_compo_file}")
         io.write_bin_info(
             contig_key_to_all_bin.values(), all_bin_compo_file, add_contigs=True
@@ -629,9 +680,9 @@ def main():
 
     selected_bins = bin_manager.select_best_bins(
         contig_key_to_all_bin,
-        min_completeness=args.min_completeness,
-        max_contamination=args.max_contamination,
-        prefix=args.prefix,
+        min_completeness=min_completeness,
+        max_contamination=max_contamination,
+        prefix=prefix,
     )
 
     logging.info(f"Writing selected bins in {final_bin_report}")
@@ -640,11 +691,18 @@ def main():
     if write_final_fasta_bins:
         io.write_bins_fasta(
             selected_bins,
-            args.contigs,
-            outdir=args.outdir / "final_bins",
+            contigs,
+            outdir=outdir / "final_bins",
             contigs_names=contigs_in_bins,
         )
 
     log_selected_bin_info(selected_bins, hq_min_completeness, hq_max_conta)
 
     return 0
+
+
+def main_main():
+    """Main function to run the application."""
+    preprocess_args()
+
+    app()

--- a/binette/main.py
+++ b/binette/main.py
@@ -636,7 +636,11 @@ def main(
 
     logging.info("Add size and assess quality of input bins")
     bin_quality.add_bin_metrics(
-        original_bins, contig_metadat, contamination_weight, threads
+        original_bins,
+        contig_metadat,
+        contamination_weight,
+        threads,
+        disable_progress_bar=not progress,
     )
     bin_quality.add_bin_size_and_N50(original_bins, contig_to_length)
 
@@ -656,6 +660,7 @@ def main(
         max_conta=max_contamination,
         min_len=min_length,
         max_len=max_length,
+        disable_progress_bar=not progress,
     )
 
     logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")
@@ -665,6 +670,7 @@ def main(
         contig_info=contig_metadat,
         contamination_weight=contamination_weight,
         threads=threads,
+        disable_progress_bar=not progress,
     )
 
     contig_key_to_all_bin = contig_key_to_original_bin | contig_key_to_new_bin

--- a/binette/main.py
+++ b/binette/main.py
@@ -600,8 +600,6 @@ def run_binette(
         with open(index_to_contig_file, "w") as flout:
             flout.write("\n".join((f"{i}\t{c}" for i, c in enumerate(contigs_in_bins))))
 
-    original_bins = list(contig_key_to_original_bin.values())
-
     if proteins and not resume:
         logging.info(f"Using the provided protein sequences file: {proteins}")
         use_existing_protein_file = True
@@ -639,13 +637,15 @@ def run_binette(
     contig_metadat["contig_to_length"] = contig_to_length
 
     logging.info("Add size and assess quality of input bins")
-    bin_quality.add_bin_metrics(
-        original_bins,
+    original_bins = bin_quality.add_bin_metrics(
+        list(contig_key_to_original_bin.values()),
         contig_metadat,
         contamination_weight,
         threads,
         disable_progress_bar=not progress,
     )
+    contig_key_to_original_bin = {b.contigs_key: b for b in original_bins}
+
     bin_quality.add_bin_size_and_N50(original_bins, contig_to_length)
 
     logging.info(
@@ -669,13 +669,14 @@ def run_binette(
 
     logging.info(f"Assess quality for {len(contig_key_to_new_bin)} intermediate bins.")
 
-    bin_quality.add_bin_metrics(
+    new_bins = bin_quality.add_bin_metrics(
         bins=contig_key_to_new_bin.values(),
         contig_info=contig_metadat,
         contamination_weight=contamination_weight,
         threads=threads,
         disable_progress_bar=not progress,
     )
+    contig_key_to_new_bin = {b.contigs_key: b for b in new_bins}
 
     contig_key_to_all_bin = contig_key_to_original_bin | contig_key_to_new_bin
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -369,7 +369,7 @@ def run_binette(
     bin_dirs: Annotated[
         Optional[List[Path]],
         typer.Option(
-            "--bin-dirs",
+            "--bin_dirs",
             "-d",
             help="List of bin folders containing each bin in a fasta file.",
             # callback=lambda x: [is_valid_file(str(p)) for p in x] if x else None,
@@ -380,7 +380,7 @@ def run_binette(
     contig2bin_tables: Annotated[
         Optional[List[Path]],
         typer.Option(
-            "--contig2bin-tables",
+            "--contig2bin_tables",
             "-b",
             help="List of contig2bin tables with two columns: contig, bin.",
             exists=True,
@@ -455,7 +455,7 @@ def run_binette(
     min_completeness: Annotated[
         int,
         typer.Option(
-            "--min-completeness",
+            "--min_completeness",
             help="Minimum completeness required for intermediate bin creation and final bin selection.",
             rich_help_panel="Bin Filtering and Scoring",
         ),
@@ -463,7 +463,7 @@ def run_binette(
     max_contamination: Annotated[
         int,
         typer.Option(
-            "--max-contamination",
+            "--max_contamination",
             help="Maximum contamination allowed for intermediate bin creation and final bin selection.",
             rich_help_panel="Bin Filtering and Scoring",
         ),
@@ -471,7 +471,7 @@ def run_binette(
     min_length: Annotated[
         int,
         typer.Option(
-            "--min-length",
+            "--min_length",
             help="Minimum length (bp) required for intermediate bin creation and final bin selection.",
             rich_help_panel="Bin Filtering and Scoring",
         ),
@@ -479,7 +479,7 @@ def run_binette(
     max_length: Annotated[
         int,
         typer.Option(
-            "--max-length",
+            "--max_length",
             help="Maximum length (bp) allowed for intermediate bin creation and final bin selection.",
             rich_help_panel="Bin Filtering and Scoring",
         ),
@@ -487,7 +487,7 @@ def run_binette(
     contamination_weight: Annotated[
         float,
         typer.Option(
-            "--contamination-weight",
+            "--contamination_weight",
             "-w",
             help="Bins are scored as: completeness - weight * contamination. A lower weight favors completeness over low contamination.",
             rich_help_panel="Bin Filtering and Scoring",
@@ -497,16 +497,16 @@ def run_binette(
     fasta_extensions: Annotated[
         List[str],
         typer.Option(
-            "--fasta-extensions",
+            "--fasta_extensions",
             "-e",
-            help="FASTA file extensions to search for in bin directories (used with --bin-dirs).",
+            help="FASTA file extensions to search for in bin directories (used with --bin_dirs).",
             rich_help_panel="Advanced Options",
         ),
     ] = [".fasta", ".fa", ".fna"],
     checkm2_db: Annotated[
         Optional[Path],
         typer.Option(
-            "--checkm2-db",
+            "--checkm2_db",
             help="Path to CheckM2 diamond database. By default the database set via <checkm2 database> is used.",
             rich_help_panel="Advanced Options",
         ),
@@ -514,7 +514,7 @@ def run_binette(
     low_mem: Annotated[
         bool,
         typer.Option(
-            "--low-mem",
+            "--low_mem",
             help="Enable low-memory mode for Diamond.",
             rich_help_panel="Advanced Options",
         ),
@@ -537,7 +537,7 @@ def run_binette(
     progress: Annotated[
         bool,
         typer.Option(
-            help="Show progress bar while fetching pangenomes (disable with --no-progress).",
+            help="Show progress bar while fetching pangenomes (disable with --no_progress).",
             rich_help_panel="Output and Runtime Control",
         ),
     ] = True,

--- a/binette/main.py
+++ b/binette/main.py
@@ -675,7 +675,6 @@ def run_binette(
         contamination_weight=contamination_weight,
         threads=threads,
         disable_progress_bar=not progress,
-        chunk_size=20000,
     )
     contig_key_to_new_bin = {b.contigs_key: b for b in new_bins}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "pandas>=2,<3",
     "pyfastx>=2,<3",
     "pyrodigal>=2,<3",
-    "tqdm>=4,<5",
     "pyroaring>=1.0.0,<2.0.0",
     "typer>=0.9.0,<1.0.0",
     "rich>=12.0.0,<14.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ Documentation = "https://binette.readthedocs.io"
 #
 #
 [project.scripts]
-binette = "binette.main:main_main"
+binette = "binette.main:main"
 
 [tool.setuptools]
 packages = ["binette"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,8 @@ classifiers=[
 requires-python = ">=3.12"
 license = {file="LICENSE"}
 
-[project.optional-dependencies]
-main_deps = [
-    # "checkm2==1.1", # not yet on Pypi
+dependencies = [
+    "checkm2 @ git+https://github.com/chklovski/CheckM2.git@1.1.0",
     "networkx>=3.0,<4.0",
     "numpy>1.24,<3.0",
     "pandas>=2,<3",
@@ -35,7 +34,11 @@ main_deps = [
     "pyrodigal>=2,<3",
     "tqdm>=4,<5",
     "pyroaring>=1.0.0,<2.0.0",
+    "typer>=0.9.0,<1.0.0",
+    "rich>=12.0.0,<14.0.0"
 ]
+
+[project.optional-dependencies]
 
 doc = [
     "sphinx==6.2.1",
@@ -64,7 +67,7 @@ Documentation = "https://binette.readthedocs.io"
 #
 #
 [project.scripts]
-binette = "binette.main:main"
+binette = "binette.main:main_main"
 
 [tool.setuptools]
 packages = ["binette"]

--- a/tests/bin_quality_test.py
+++ b/tests/bin_quality_test.py
@@ -7,12 +7,12 @@ import pandas as pd
 from unittest.mock import Mock, patch
 
 from unittest.mock import Mock, patch
+from binette.bin_manager import Bin
 from binette.bin_quality import (
-    Bin,
     add_bin_metrics,
-    assess_bins_quality_by_chunk,
     assess_bins_quality,
     chunks,
+    balanced_chunks,
     get_diamond_feature_per_bin_df,
     get_bins_metadata_df,
 )
@@ -191,3 +191,124 @@ def test_add_bin_size_and_N50():
     assert bins[0].N50 == 1500
     assert bins[1].length == 3500
     assert bins[1].N50 == 2000
+
+
+def test_balanced_chunks_normal_distribution():
+    """Test balanced_chunks with normal distribution scenarios."""
+
+    # Test case: 50 bins with 8 threads
+    bins_50 = list(range(50))
+    chunks_50_8 = list(balanced_chunks(bins_50, 8))
+
+    assert len(chunks_50_8) == 8
+    # 50 / 8 = 6 remainder 2, so first 2 chunks get 7 items, rest get 6
+    chunk_sizes = [len(chunk) for chunk in chunks_50_8]
+    assert chunk_sizes == [7, 7, 6, 6, 6, 6, 6, 6]
+    # Verify all items are included
+    all_items = [item for chunk in chunks_50_8 for item in chunk]
+    assert sorted(all_items) == bins_50
+
+
+def test_balanced_chunks_large_dataset():
+    """Test balanced_chunks with larger datasets."""
+
+    # Test case: 100 bins with 8 threads
+    bins_100 = list(range(100))
+    chunks_100_8 = list(balanced_chunks(bins_100, 8))
+
+    assert len(chunks_100_8) == 8
+    # 100 / 8 = 12 remainder 4, so first 4 chunks get 13 items, rest get 12
+    chunk_sizes = [len(chunk) for chunk in chunks_100_8]
+    assert chunk_sizes == [13, 13, 13, 13, 12, 12, 12, 12]
+    # Verify all items are included
+    all_items = [item for chunk in chunks_100_8 for item in chunk]
+    assert sorted(all_items) == bins_100
+
+
+def test_balanced_chunks_fewer_items_than_chunks():
+    """Test balanced_chunks when there are fewer items than requested chunks."""
+
+    bins_5 = list(range(5))
+    chunks_5_8 = list(balanced_chunks(bins_5, 8))
+
+    assert len(chunks_5_8) == 5  # Should only create 5 chunks
+    chunk_sizes = [len(chunk) for chunk in chunks_5_8]
+    assert chunk_sizes == [1, 1, 1, 1, 1]
+    # Verify all items are included
+    all_items = [item for chunk in chunks_5_8 for item in chunk]
+    assert sorted(all_items) == bins_5
+
+
+def test_balanced_chunks_empty_list():
+    """Test balanced_chunks with empty input."""
+
+    bins_empty = []
+    chunks_empty = list(balanced_chunks(bins_empty, 8))
+
+    assert chunks_empty == []
+
+
+def test_balanced_chunks_single_item():
+    """Test balanced_chunks with single item."""
+
+    bins_1 = [42]
+    chunks_1 = list(balanced_chunks(bins_1, 8))
+
+    assert len(chunks_1) == 1
+    assert chunks_1[0] == [42]
+
+
+def test_balanced_chunks_exact_division():
+    """Test balanced_chunks when items divide evenly into chunks."""
+
+    bins_16 = list(range(16))
+    chunks_16_4 = list(balanced_chunks(bins_16, 4))
+
+    assert len(chunks_16_4) == 4
+    chunk_sizes = [len(chunk) for chunk in chunks_16_4]
+    assert chunk_sizes == [4, 4, 4, 4]
+    # Verify all items are included
+    all_items = [item for chunk in chunks_16_4 for item in chunk]
+    assert sorted(all_items) == bins_16
+
+
+def test_balanced_chunks_string_items():
+    """Test balanced_chunks with non-numeric items."""
+
+    bins_strings = ["bin_a", "bin_b", "bin_c", "bin_d", "bin_e"]
+    chunks_strings = list(balanced_chunks(bins_strings, 3))
+
+    assert len(chunks_strings) == 3
+    # 5 / 3 = 1 remainder 2, so first 2 chunks get 2 items, last gets 1
+    chunk_sizes = [len(chunk) for chunk in chunks_strings]
+    assert chunk_sizes == [2, 2, 1]
+    # Verify all items are included
+    all_items = [item for chunk in chunks_strings for item in chunk]
+    assert sorted(all_items) == sorted(bins_strings)
+
+
+def test_balanced_chunks_single_thread():
+    """Test balanced_chunks with single thread (one chunk)."""
+
+    bins_3 = [1, 2, 3]
+    chunks_3_1 = list(balanced_chunks(bins_3, 1))
+
+    assert len(chunks_3_1) == 1
+    assert chunks_3_1[0] == [1, 2, 3]
+
+
+def test_balanced_chunks_distribution_properties():
+    """Test that balanced_chunks maintains balanced distribution properties."""
+
+    # Test the specific example from the conversation - 100 bins, 8 threads
+    # This should create 8 chunks instead of 9 to match the number of threads
+    bins_100_example = list(range(100))
+    chunks_100_example = list(balanced_chunks(bins_100_example, 8))
+
+    assert len(chunks_100_example) == 8
+    # Verify the distribution is balanced
+    chunk_sizes_example = [len(chunk) for chunk in chunks_100_example]
+    min_size = min(chunk_sizes_example)
+    max_size = max(chunk_sizes_example)
+    assert max_size - min_size <= 1  # Difference should be at most 1
+    assert sum(chunk_sizes_example) == 100  # All items included

--- a/tests/main_binette_test.py
+++ b/tests/main_binette_test.py
@@ -4,11 +4,7 @@ from binette.main import (
     log_selected_bin_info,
     manage_protein_alignement,
     parse_input_files,
-    parse_arguments,
-    init_logging,
     main,
-    UniqueStore,
-    is_valid_file,
 )
 from binette.bin_manager import Bin
 from binette import diamond, contig_manager, cds
@@ -226,90 +222,6 @@ def test_parse_input_files_bin_dirs(create_temp_bin_directories, tmp_path):
     assert len(contig_id_to_length) == 5
 
 
-def test_argument_used_once():
-    # Test UniqueStore class
-    parser = ArgumentParser(description="Test parser")
-    parser.add_argument("--example", action=UniqueStore, help="Example argument")
-    args = parser.parse_args(["--example", "value"])
-    assert args.example == "value"
-
-
-def test_argument_used_multiple_times():
-    # Test UniqueStore class
-    parser = ArgumentParser(description="Test parser")
-    parser.add_argument("--example", action=UniqueStore, help="Example argument")
-    with pytest.raises(SystemExit):
-        parser.parse_args(["--example", "value", "--example", "value2"])
-
-
-def test_parse_arguments_required_arguments(test_environment):
-    """
-    Test parsing when only required arguments are provided.
-    Ensure that input arguments exist before parsing.
-    """
-    # Create temporary directories and files
-    folder1, folder2, contigs_file = test_environment
-
-    # Parse arguments with existing files and directories
-    args = parse_arguments(["-d", str(folder1), str(folder2), "-c", str(contigs_file)])
-
-    # Assert that the parsed arguments match the expected paths
-    assert args.bin_dirs == [folder1, folder2]
-    assert args.contigs == contigs_file
-
-
-def test_parse_arguments_optional_arguments(test_environment):
-    # Test when required and optional arguments are provided
-
-    # Create temporary directories and files
-    folder1, folder2, contigs_file = test_environment
-
-    # Parse arguments with existing files and directories
-    args = parse_arguments(
-        [
-            "-d",
-            str(folder1),
-            str(folder2),
-            "-c",
-            str(contigs_file),
-            "--threads",
-            "4",
-            "--outdir",
-            "output",
-        ]
-    )
-    assert args.bin_dirs == [folder1, folder2]
-    assert args.contigs == contigs_file
-    assert args.threads == 4
-    assert args.outdir == Path("output")
-
-
-def test_parse_arguments_invalid_arguments():
-    # Test when invalid arguments are provided
-    with pytest.raises(SystemExit):
-        # In this case, required arguments are missing
-        parse_arguments(["-t", "4"])
-
-
-def test_parse_arguments_help():
-    # Test the help message
-    with pytest.raises(SystemExit) as pytest_wrapped_e:
-        parse_arguments(["-h"])
-    assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 0
-
-
-def test_init_logging_command_line(caplog):
-
-    caplog.set_level(logging.INFO)
-
-    init_logging(verbose=True, debug=False)
-    expected_log_message = f'command line: {" ".join(sys.argv)}'
-    # Check if the log message is present in the log records
-
-    assert expected_log_message in caplog.text
-
-
 # @patch('diamond.run')
 def test_manage_protein_alignment_no_resume(tmp_path):
     # Set up the input parameters
@@ -387,26 +299,3 @@ def test_main_resume_when_not_possible(monkeypatch, test_environment):
     # Call the main function
     with pytest.raises(FileNotFoundError):
         main()
-
-
-def test_is_valid_file_existing_file(tmp_path: Path):
-    """Test is_valid_file with a file that exists."""
-    # Create a temporary file
-    test_file = tmp_path / "test_file.txt"
-    test_file.write_text("Sample content")
-
-    parser = ArgumentParser()
-
-    # Assert that the function correctly returns the file path
-    result = is_valid_file(parser, str(test_file))
-    assert result == test_file
-
-
-def test_is_valid_file_non_existing_file():
-    """Test is_valid_file with a file that does not exist."""
-    parser = ArgumentParser()
-    non_existing_file = "non_existing_file.txt"
-
-    # Expect the function to call parser.error, which will raise a SystemExit exception
-    with pytest.raises(SystemExit):
-        is_valid_file(parser, non_existing_file)


### PR DESCRIPTION
Bin quality assessment in Binette was running sequentially, underutilizing CPU and becoming the main bottleneck when processing a lot of bins as mentioned in #71 .

## Added in this PR:
* Added multiprocessing with **joblib** to run bin quality assessment in parallel.
* Use sequential mode when one CPU is given or when bins count is too small to benefit from parallelism (less than 6k bins). 
