### PR TITLE
Drop support for pyrodigal v2

### DIFF
--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -44,6 +44,7 @@ jobs:
 
     # Install requirements 
     - uses: conda-incubator/setup-miniconda@v3
+      if: steps.cache-conda.outputs.cache-hit != 'true'
       with:
         # mamba-version: "*"
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -34,6 +34,7 @@ jobs:
         channels: conda-forge,bioconda
         environment-file: binette.yaml
         activate-environment: binette
+        conda-remove-defaults: true
   
     - name: Install binette
       run: |

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -26,43 +26,27 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    # Cache conda packages (not the environment itself)
-    - name: Cache conda packages
-      uses: actions/cache@v4
-      id: cache-conda-pkgs
-      with:
-        path: |
-          ~/conda_pkgs_dir
-          ~/.conda/pkgs
-        key: conda-pkgs-${{ runner.os }}-${{ hashFiles('binette.yaml') }}
-        restore-keys: |
-          conda-pkgs-${{ runner.os }}-
 
-    # Show cache status for debugging
-    - name: Cache status
-      run: |
-        if [ "${{ steps.cache-conda-pkgs.outputs.cache-hit }}" == "true" ]; then
-          echo "✅ Conda packages loaded from cache"
-        else
-          echo "⏬ Conda packages will be downloaded (cache miss)"
-        fi
+    # # Always create the environment (but use cached packages when available)
+    # - name: Setup conda environment
+    #   uses: conda-incubator/setup-miniconda@v3
+    #   with:
+    #     python-version: ${{ matrix.python-version }}
+    #     channels: conda-forge,bioconda
+    #     environment-file: binette.yaml
+    #     activate-environment: binette
+    #     conda-remove-defaults: true
 
-    # Always create the environment (but use cached packages when available)
-    - name: Setup conda environment
-      uses: conda-incubator/setup-miniconda@v3
+    - name : Setup micromamba environment
+      uses: mamba-org/setup-micromamba@v2
       with:
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge,bioconda
         environment-file: binette.yaml
-        activate-environment: binette
-        conda-remove-defaults: true
-  
+        create-args: python=${{ matrix.python-version }}
+        cache-environment: true
+
+
     - name: Install binette
       run: |
-        echo "🔍 Verifying conda environment..."
-        conda info --envs
-        conda list -n binette | head -20
-        echo "📦 Installing binette..."
         pip install .
         binette -h
 

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'macos-13']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: [3.12] #["3.8", "3.9", "3.10"]
 
     steps:

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -26,53 +26,44 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    
-      # Cache conda environment
-    - name: Cache conda environment
+    # Cache conda packages (not the environment itself)
+    - name: Cache conda packages
       uses: actions/cache@v4
-      id: cache-conda
+      id: cache-conda-pkgs
       with:
         path: |
-          /usr/share/miniconda/envs/binette
-          ~/.conda/envs/binette
-          ~/miniconda3/envs/binette
-          /Users/runner/miniconda3/envs/binette
-        key: conda-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('binette.yml', 'pyproject.toml') }}-v1
+          ~/conda_pkgs_dir
+          ~/.conda/pkgs
+        key: conda-pkgs-${{ runner.os }}-${{ hashFiles('binette.yaml') }}
         restore-keys: |
-          conda-${{ runner.os }}-python${{ matrix.python-version }}-
-            conda-${{ runner.os }}-
+          conda-pkgs-${{ runner.os }}-
 
-    - name: Create conda environment
+    # Show cache status for debugging
+    - name: Cache status
+      run: |
+        if [ "${{ steps.cache-conda-pkgs.outputs.cache-hit }}" == "true" ]; then
+          echo "✅ Conda packages loaded from cache"
+        else
+          echo "⏬ Conda packages will be downloaded (cache miss)"
+        fi
+
+    # Always create the environment (but use cached packages when available)
+    - name: Setup conda environment
       uses: conda-incubator/setup-miniconda@v3
-      if: steps.cache-conda.outputs.cache-hit != 'true'
       with:
-        # mamba-version: "*"
         python-version: ${{ matrix.python-version }}
         channels: conda-forge,bioconda
         environment-file: binette.yaml
         activate-environment: binette
         conda-remove-defaults: true
-
-        # If cache hit, just activate the cached environment
-    - name: Activate cached conda environment
-      uses: conda-incubator/setup-miniconda@v3
-      if: steps.cache-conda.outputs.cache-hit == 'true'
-      with:
-        python-version: ${{ matrix.python-version }}
-        activate-environment: binette
-
-    # Show cache status for debugging
-    - name: Cache status
-      run: |
-        if [ "${{ steps.cache-conda.outputs.cache-hit }}" == "true" ]; then
-          echo "✅ Conda environment loaded from cache"
-        else
-          echo "⏬ Conda environment created fresh (cache miss)"
-        fi
+        use-only-tar-bz2: true
   
     - name: Install binette
       run: |
-        conda list
+        echo "🔍 Verifying conda environment..."
+        conda info --envs
+        conda list -n binette | head -20
+        echo "📦 Installing binette..."
         pip install .
         binette -h
 

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -42,8 +42,8 @@ jobs:
           conda-${{ runner.os }}-python${{ matrix.python-version }}-
             conda-${{ runner.os }}-
 
-    # Install requirements 
-    - uses: conda-incubator/setup-miniconda@v3
+    - name: Create conda environment
+      uses: conda-incubator/setup-miniconda@v3
       if: steps.cache-conda.outputs.cache-hit != 'true'
       with:
         # mamba-version: "*"
@@ -54,7 +54,8 @@ jobs:
         conda-remove-defaults: true
 
         # If cache hit, just activate the cached environment
-    - uses: conda-incubator/setup-miniconda@v3
+    - name: Activate cached conda environment
+      uses: conda-incubator/setup-miniconda@v3
       if: steps.cache-conda.outputs.cache-hit == 'true'
       with:
         python-version: ${{ matrix.python-version }}
@@ -72,6 +73,7 @@ jobs:
   
     - name: Install binette
       run: |
+        conda list
         pip install .
         binette -h
 

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -60,7 +60,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: binette
-        auto-activate-base: false
 
     # Show cache status for debugging
     - name: Cache status

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -26,6 +26,28 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
+    # Cache conda packages and environment
+    - name: Cache conda environment
+      id: cache-conda
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/conda_pkgs_dir
+          /usr/share/miniconda/envs/binette
+        key: conda-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('binette.yaml') }}
+        restore-keys: |
+          conda-${{ runner.os }}-python${{ matrix.python-version }}-
+          conda-${{ runner.os }}-
+
+    # Check cache status
+    - name: Check conda cache status
+      run: |
+        if [ "${{ steps.cache-conda.outputs.cache-hit }}" = "true" ]; then
+          echo "✅ Conda environment restored from cache"
+        else
+          echo "⚠️  Conda environment cache miss - will create fresh environment"
+        fi
+
     # Install requirements 
     - uses: conda-incubator/setup-miniconda@v3
       with:
@@ -35,6 +57,8 @@ jobs:
         environment-file: binette.yaml
         activate-environment: binette
         conda-remove-defaults: true
+        use-only-tar-bz2: true
+        show-channel-urls: true
   
     - name: Install binette
       run: |

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -33,10 +33,10 @@ jobs:
       id: cache-conda
       with:
         path: |
-          /usr/share/miniconda/envs/panorama
-          ~/.conda/envs/panorama
-          ~/miniconda3/envs/panorama
-          /Users/runner/miniconda3/envs/panorama
+          /usr/share/miniconda/envs/binette
+          ~/.conda/envs/binette
+          ~/miniconda3/envs/binette
+          /Users/runner/miniconda3/envs/binette
         key: conda-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('binette.yml', 'pyproject.toml') }}-v1
         restore-keys: |
           conda-${{ runner.os }}-python${{ matrix.python-version }}-

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -56,7 +56,6 @@ jobs:
         environment-file: binette.yaml
         activate-environment: binette
         conda-remove-defaults: true
-        use-only-tar-bz2: true
   
     - name: Install binette
       run: |

--- a/.github/workflows/binette_ci.yml
+++ b/.github/workflows/binette_ci.yml
@@ -26,27 +26,21 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    # Cache conda packages and environment
+    
+      # Cache conda environment
     - name: Cache conda environment
-      id: cache-conda
       uses: actions/cache@v4
+      id: cache-conda
       with:
         path: |
-          ~/conda_pkgs_dir
-          /usr/share/miniconda/envs/binette
-        key: conda-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('binette.yaml') }}
+          /usr/share/miniconda/envs/panorama
+          ~/.conda/envs/panorama
+          ~/miniconda3/envs/panorama
+          /Users/runner/miniconda3/envs/panorama
+        key: conda-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('binette.yml', 'pyproject.toml') }}-v1
         restore-keys: |
           conda-${{ runner.os }}-python${{ matrix.python-version }}-
-          conda-${{ runner.os }}-
-
-    # Check cache status
-    - name: Check conda cache status
-      run: |
-        if [ "${{ steps.cache-conda.outputs.cache-hit }}" = "true" ]; then
-          echo "✅ Conda environment restored from cache"
-        else
-          echo "⚠️  Conda environment cache miss - will create fresh environment"
-        fi
+            conda-${{ runner.os }}-
 
     # Install requirements 
     - uses: conda-incubator/setup-miniconda@v3
@@ -57,8 +51,23 @@ jobs:
         environment-file: binette.yaml
         activate-environment: binette
         conda-remove-defaults: true
-        use-only-tar-bz2: true
-        show-channel-urls: true
+
+        # If cache hit, just activate the cached environment
+    - uses: conda-incubator/setup-miniconda@v3
+      if: steps.cache-conda.outputs.cache-hit == 'true'
+      with:
+        python-version: ${{ matrix.python-version }}
+        activate-environment: binette
+        auto-activate-base: false
+
+    # Show cache status for debugging
+    - name: Cache status
+      run: |
+        if [ "${{ steps.cache-conda.outputs.cache-hit }}" == "true" ]; then
+          echo "✅ Conda environment loaded from cache"
+        else
+          echo "⏬ Conda environment created fresh (cache miss)"
+        fi
   
     - name: Install binette
       run: |

--- a/binette.yaml
+++ b/binette.yaml
@@ -13,7 +13,7 @@ dependencies:
   - packaging>=23,<24
   - networkx>=3.0,<4.0
   - pyfastx>=2,<4
-  - pyrodigal
+  - pyrodigal>=3,<4
   - pyroaring>=1.0,<2.0
   - typer>=0.9.0
   - rich>=12.0.0

--- a/binette/cds.py
+++ b/binette/cds.py
@@ -37,11 +37,8 @@ def predict(
 
     :return: A dictionary mapping contig names to predicted genes.
     """
-    try:
-        # for version >=3 of pyrodigal
-        orf_finder = pyrodigal.GeneFinder(meta="meta")  # type: ignore
-    except AttributeError:
-        orf_finder = pyrodigal.OrfFinder(meta="meta")  # type: ignore
+
+    orf_finder = pyrodigal.GeneFinder(meta="meta")
 
     logger.info(f"Predicting CDS sequences with Pyrodigal using {threads} threads")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,12 @@ requires-python = ">=3.12"
 
 dependencies = [
     "checkm2 @ git+https://github.com/chklovski/CheckM2.git@1.1.0",
+    "joblib>=1.0,<2.0",
     "networkx>=3.0,<4.0",
     "numpy>1.24,<3.0",
     "pandas>=2,<3",
     "pyfastx>=2,<3",
-    "pyrodigal>=2,<3",
+    "pyrodigal>=3,<4",
     "pyroaring>=1.0.0,<2.0.0",
     "typer>=0.9.0,<1.0.0",
     "rich>=12.0.0,<14.0.0"


### PR DESCRIPTION
Drop support for pyrodigal v2 as its performance was quite bad compared to v3. 
Also cached conda env in the CI
 