### PR TITLE
Output simple table  contig to bin of final bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ Binette results are stored in the `results` directory. You can specify a differe
 
 In this directory you will find:
 - **`final_bins_quality_reports.tsv`**: This is a TSV (tab-separated values) file containing quality information about the final selected bins.
-- **`final_bins/`**: This directory stores all the selected bins in fasta format.
+- **`final_bins/`**: This directory stores all the selected bins in fasta format. Can be skipped with `--no-write-fasta-bins`.
+- **`final_contig_to_bin.tsv`**: A headerless TSV file mapping each contig to its assigned bin. This format is much lighter than the fasta output to describe the final Binette bins.
 - **`input_bins_quality_reports/`**: A directory storing quality reports for the input bin sets, with files following the same structure as `final_bins_quality_reports.tsv`.
 - **`temporary_files/`**: This directory contains intermediate files. If you choose to use the `--resume` option, Binette will utilize files in this directory to prevent the recomputation of time-consuming steps.
 

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -307,17 +307,17 @@ def write_contig2bin_table(
     :param contigs_names: List of contig names where index corresponds to contig ID.
     """
     logger.info(f"Writing contig2bin table to '{output_file}'")
-    
+
     # Ensure output directory exists
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    
+
     with open(output_file, "w") as f:
         # Write contig to bin mappings
         for bin_obj in selected_bins:
             for contig_index in bin_obj.contigs:
                 contig_name = contigs_names[contig_index]
                 f.write(f"{contig_name}\t{bin_obj.name}\n")
-    
+
     total_entries = sum(len(bin_obj.contigs) for bin_obj in selected_bins)
     logger.debug(f"Successfully wrote contig2bin table with {total_entries} entries")
 

--- a/binette/io_manager.py
+++ b/binette/io_manager.py
@@ -294,6 +294,34 @@ def check_resume_file(faa_file: Path, diamond_result_file: Path) -> None:
         raise FileNotFoundError(error_msg)
 
 
+def write_contig2bin_table(
+    selected_bins: list[Bin],
+    output_file: Path,
+    contigs_names: list[str],
+):
+    """
+    Write a simple TSV file mapping contig IDs to bin IDs.
+
+    :param selected_bins: List of selected Bin objects.
+    :param output_file: Path to the output TSV file.
+    :param contigs_names: List of contig names where index corresponds to contig ID.
+    """
+    logger.info(f"Writing contig2bin table to '{output_file}'")
+    
+    # Ensure output directory exists
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    
+    with open(output_file, "w") as f:
+        # Write contig to bin mappings
+        for bin_obj in selected_bins:
+            for contig_index in bin_obj.contigs:
+                contig_name = contigs_names[contig_index]
+                f.write(f"{contig_name}\t{bin_obj.name}\n")
+    
+    total_entries = sum(len(bin_obj.contigs) for bin_obj in selected_bins)
+    logger.debug(f"Successfully wrote contig2bin table with {total_entries} entries")
+
+
 def write_original_bin_metrics(original_bins: list[Bin], original_bin_report_dir: Path):
     """
     Write metrics of original input bins to a specified directory.

--- a/binette/main.py
+++ b/binette/main.py
@@ -20,16 +20,8 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 import binette as binette_init
-from binette import (
-    bin_manager,
-    bin_quality,
-    cds,
-    contig_manager,
-    diamond,
-)
-from binette import (
-    io_manager as io,
-)
+from binette import bin_manager, bin_quality, cds, contig_manager, diamond
+from binette import io_manager as io
 
 logger = logging.getLogger(__name__)
 err_console = Console(stderr=True)
@@ -730,7 +722,7 @@ def binette(
 
     io.write_contig2bin_table(
         selected_bins,
-        outdir / "final_contig2bin.tsv",
+        outdir / "final_contig_to_bin.tsv",
         contigs_in_bins,
     )
 

--- a/binette/main.py
+++ b/binette/main.py
@@ -722,12 +722,20 @@ def binette(
         prefix=prefix,
     )
 
-    logger.info(f"Writing selected bins to '{final_bin_report}'")
     if contig_to_coding_length:
         bin_quality.add_bin_coding_density(selected_bins, contig_to_coding_length)
+
+    logger.info(f"Writing selected bins information to '{final_bin_report}'")
     io.write_bin_info(selected_bins, output=final_bin_report)
 
+    io.write_contig2bin_table(
+        selected_bins,
+        outdir / "final_contig2bin.tsv",
+        contigs_in_bins,
+    )
+
     if write_fasta_bins:
+        logger.info(f"Writing selected bins FASTA files to '{outdir / 'final_bins'}'")
         io.write_bins_fasta(
             selected_bins,
             contigs,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,7 +83,8 @@ Binette results are stored in the `results` directory. You can specify a differe
 
 In this directory you will find:
 - `final_bins_quality_reports.tsv`: This is a TSV (tab-separated values) file containing quality information about the final selected bins.
-- `final_bins/`: This directory stores all the selected bins in fasta format.
+- `final_bins/`: This directory stores all the selected bins in fasta format. Can be skipped with `--no-write-fasta-bins`.
+- `final_contig_to_bin.tsv`: A headerless TSV file mapping each contig to its assigned bin. This format is much lighter than the fasta output to describe the final Binette bins.
 - `input_bins_quality_reports/`: A directory storing quality reports for the input bin sets, with files following the same structure as `final_bins_quality_reports.tsv`.
 - `temporary_files/`: This directory contains intermediate files. If you choose to use the `--resume` option, Binette will utilize files in this directory to prevent the recomputation of time-consuming steps.
 

--- a/tests/functional_tests/test_binette_command.py
+++ b/tests/functional_tests/test_binette_command.py
@@ -41,19 +41,18 @@ def test_wrong_input(tmp_path):
     )
     assert result.exit_code == 1
 
+
 def compare_results(result_file: Path, expected_file: Path):
     content_actual = result_file.read_text()
     content_expected = expected_file.read_text()
     print(content_actual)
     assert content_actual == content_expected, (
-        f"Content mismatch for {result_file}. "
-        f"Expected content from {expected_file}."
+        f"Content mismatch for {result_file}. Expected content from {expected_file}."
     )
 
 
 @pytest.mark.requires_test_data
 def test_bin_dir_input(test_data_path: Path, tmp_path):
-
     binning_results_dir = test_data_path / "binning_results"
 
     cmd_args = [
@@ -69,23 +68,24 @@ def test_bin_dir_input(test_data_path: Path, tmp_path):
         test_data_path / "checkm2_tiny_db/checkm2_tiny_db.dmnd",
         "-o",
         tmp_path / "test_results_from_dirs",
-        "-v"
+        "-v",
     ]
     cmd_args = [arg.as_posix() if isinstance(arg, Path) else arg for arg in cmd_args]
-    
+
     result = runner.invoke(app, cmd_args)
     print(result.output)
     print(result.stderr)
     assert result.exit_code == 0
 
-    result_table = tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    result_table = (
+        tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    )
     expected_table = Path("tests/expected_results/final_bins_quality_reports.tsv")
-    compare_results(result_table, expected_table)    
+    compare_results(result_table, expected_table)
 
 
 @pytest.mark.requires_test_data
 def test_bin_tables_input_and_resume(test_data_path: Path, tmp_path):
-
     binning_results_dir = test_data_path / "binning_results"
 
     cmd_args = [
@@ -101,19 +101,21 @@ def test_bin_tables_input_and_resume(test_data_path: Path, tmp_path):
         test_data_path / "checkm2_tiny_db/checkm2_tiny_db.dmnd",
         "-o",
         tmp_path / "test_results_from_dirs",
-        "-v"
+        "-v",
     ]
     cmd_args = [arg.as_posix() if isinstance(arg, Path) else arg for arg in cmd_args]
-    
+
     result = runner.invoke(app, cmd_args)
     print(result.output)
     print(result.stderr)
 
     assert result.exit_code == 0
 
-    result_table = tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    result_table = (
+        tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    )
     expected_table = Path("tests/expected_results/final_bins_quality_reports.tsv")
-    compare_results(result_table, expected_table)    
+    compare_results(result_table, expected_table)
 
     cmd_args.append("--resume")
     result = runner.invoke(app, cmd_args)
@@ -129,7 +131,6 @@ def test_bin_tables_input_and_resume(test_data_path: Path, tmp_path):
 
 @pytest.mark.requires_test_data
 def test_bin_tables_input_and_protein_input(test_data_path: Path, tmp_path):
-
     binning_results_dir = test_data_path / "binning_results"
 
     cmd_args = [
@@ -143,22 +144,24 @@ def test_bin_tables_input_and_protein_input(test_data_path: Path, tmp_path):
         test_data_path / "all_contigs.fna",
         "--checkm2_db",
         test_data_path / "checkm2_tiny_db/checkm2_tiny_db.dmnd",
-        "--proteins", 
+        "--proteins",
         test_data_path / "proteins.faa",
         "-o",
         tmp_path / "test_results_from_dirs",
-        "-v"
+        "-v",
     ]
     cmd_args = [arg.as_posix() if isinstance(arg, Path) else arg for arg in cmd_args]
-    
+
     result = runner.invoke(app, cmd_args)
     print(result.output)
     print(result.stderr)
 
     assert result.exit_code == 0
 
-    result_table = tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    result_table = (
+        tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    )
     expected_table = Path(
         "tests/expected_results/final_bins_quality_reports_from_proteins_input.tsv"
     )
-    compare_results(result_table, expected_table)    
+    compare_results(result_table, expected_table)


### PR DESCRIPTION
This output can be useful in certain contexts. It presents the final bins in a much lighter way than the Fasta version. 
It can be useful when the '--no-write-fasta-bins' option is used to output the final binette results. 