### PR TITLE
Add a `--quiet` flag to silence INFO logging 

### DIFF
--- a/binette/main.py
+++ b/binette/main.py
@@ -48,14 +48,17 @@ def version_callback(
         raise typer.Exit()
 
 
-def verbose_callback(
-    verbose: bool,
-):
-    """Sets the logging level to DEBUG if --verbose is passed."""
-    lvl = logging.INFO
+def setup_logging(verbose: bool = False, quiet: bool = False):
+    """Sets up logging configuration based on verbosity flags."""
+    if quiet and verbose:
+        raise typer.BadParameter("Cannot specify both --verbose and --quiet")
 
-    if verbose:
+    if quiet:
+        lvl = logging.WARNING
+    elif verbose:
         lvl = logging.DEBUG
+    else:
+        lvl = logging.INFO
 
     # Set up logging
     logging.basicConfig(
@@ -64,8 +67,27 @@ def verbose_callback(
         datefmt="[%X]",
         handlers=[RichHandler(console=err_console)],
     )
-    logger.info("Program started")
-    logger.info(f"Command line: {' '.join(sys.argv)}")
+
+    # Only log startup messages if not in quiet mode
+    if not quiet:
+        logger.info("Program started")
+        logger.info(f"Command line: {' '.join(sys.argv)}")
+
+
+def verbose_callback(
+    verbose: bool,
+):
+    """Sets the logging level to DEBUG if --verbose is passed."""
+    # This is a placeholder - actual setup happens in the main function
+    return verbose
+
+
+def quiet_callback(
+    quiet: bool,
+):
+    """Sets the logging level to WARNING if --quiet is passed."""
+    # This is a placeholder - actual setup happens in the main function
+    return quiet
 
 
 def preprocess_args():
@@ -449,8 +471,18 @@ def binette(
         typer.Option(
             "--verbose",
             "-v",
-            help="Enable verbose logging.",
+            help="Enable verbose mode (show detailed debug information).",
             callback=verbose_callback,
+            rich_help_panel="Output and Runtime Control",
+        ),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Enable quiet mode (only show warnings and errors).",
+            callback=quiet_callback,
             rich_help_panel="Output and Runtime Control",
         ),
     ] = False,
@@ -565,6 +597,9 @@ def binette(
 ) -> int:
     """Orchestrate the execution of the program"""
 
+    # Set up logging based on verbosity flags
+    setup_logging(verbose=verbose, quiet=quiet)
+
     # Validate that exactly one of bin_dirs or contig2bin_tables is provided
     if bin_dirs is None and contig2bin_tables is None:
         typer.echo(
@@ -665,7 +700,7 @@ def binette(
         contig_metadat,
         contamination_weight,
         threads,
-        disable_progress_bar=not progress,
+        disable_progress_bar=not progress or quiet,
     )
     contig_key_to_original_bin = {b.contigs_key: b for b in original_bins}
 
@@ -690,7 +725,7 @@ def binette(
         max_conta=max_contamination,
         min_len=min_length,
         max_len=max_length,
-        disable_progress_bar=not progress,
+        disable_progress_bar=not progress or quiet,
     )
 
     logger.info(f"Assessing quality for {len(contig_key_to_new_bin)} intermediate bins")
@@ -700,7 +735,7 @@ def binette(
         contig_info=contig_metadat,
         contamination_weight=contamination_weight,
         threads=threads,
-        disable_progress_bar=not progress,
+        disable_progress_bar=not progress or quiet,
     )
     contig_key_to_new_bin = {b.contigs_key: b for b in new_bins}
 

--- a/tests/functional_tests/test_binette_command.py
+++ b/tests/functional_tests/test_binette_command.py
@@ -1,9 +1,10 @@
+import logging
+from pathlib import Path
+
+import pytest
 from typer.testing import CliRunner
 
 from binette.main import app
-import pytest
-import logging
-from pathlib import Path
 
 runner = CliRunner()
 logger = logging.getLogger(__name__)
@@ -41,19 +42,18 @@ def test_wrong_input(tmp_path):
     )
     assert result.exit_code == 1
 
+
 def compare_results(result_file: Path, expected_file: Path):
     content_actual = result_file.read_text()
     content_expected = expected_file.read_text()
     print(content_actual)
     assert content_actual == content_expected, (
-        f"Content mismatch for {result_file}. "
-        f"Expected content from {expected_file}."
+        f"Content mismatch for {result_file}. Expected content from {expected_file}."
     )
 
 
 @pytest.mark.requires_test_data
 def test_bin_dir_input(test_data_path: Path, tmp_path):
-
     binning_results_dir = test_data_path / "binning_results"
 
     cmd_args = [
@@ -69,23 +69,24 @@ def test_bin_dir_input(test_data_path: Path, tmp_path):
         test_data_path / "checkm2_tiny_db/checkm2_tiny_db.dmnd",
         "-o",
         tmp_path / "test_results_from_dirs",
-        "-v"
+        "-v",
     ]
     cmd_args = [arg.as_posix() if isinstance(arg, Path) else arg for arg in cmd_args]
-    
+
     result = runner.invoke(app, cmd_args)
     print(result.output)
     print(result.stderr)
     assert result.exit_code == 0
 
-    result_table = tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    result_table = (
+        tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    )
     expected_table = Path("tests/expected_results/final_bins_quality_reports.tsv")
-    compare_results(result_table, expected_table)    
+    compare_results(result_table, expected_table)
 
 
 @pytest.mark.requires_test_data
 def test_bin_tables_input_and_resume(test_data_path: Path, tmp_path):
-
     binning_results_dir = test_data_path / "binning_results"
 
     cmd_args = [
@@ -101,19 +102,21 @@ def test_bin_tables_input_and_resume(test_data_path: Path, tmp_path):
         test_data_path / "checkm2_tiny_db/checkm2_tiny_db.dmnd",
         "-o",
         tmp_path / "test_results_from_dirs",
-        "-v"
+        "-v",
     ]
     cmd_args = [arg.as_posix() if isinstance(arg, Path) else arg for arg in cmd_args]
-    
+
     result = runner.invoke(app, cmd_args)
     print(result.output)
     print(result.stderr)
 
     assert result.exit_code == 0
 
-    result_table = tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    result_table = (
+        tmp_path / "test_results_from_dirs" / "final_bins_quality_reports.tsv"
+    )
     expected_table = Path("tests/expected_results/final_bins_quality_reports.tsv")
-    compare_results(result_table, expected_table)    
+    compare_results(result_table, expected_table)
 
     cmd_args.append("--resume")
     result = runner.invoke(app, cmd_args)
@@ -129,7 +132,6 @@ def test_bin_tables_input_and_resume(test_data_path: Path, tmp_path):
 
 @pytest.mark.requires_test_data
 def test_bin_tables_input_and_protein_input(test_data_path: Path, tmp_path):
-
     binning_results_dir = test_data_path / "binning_results"
 
     cmd_args = [
@@ -143,14 +145,14 @@ def test_bin_tables_input_and_protein_input(test_data_path: Path, tmp_path):
         test_data_path / "all_contigs.fna",
         "--checkm2_db",
         test_data_path / "checkm2_tiny_db/checkm2_tiny_db.dmnd",
-        "--proteins", 
+        "--proteins",
         test_data_path / "proteins.faa",
         "-o",
         tmp_path / "test_results_from_dirs",
-        "-v"
+        "-v",
     ]
     cmd_args = [arg.as_posix() if isinstance(arg, Path) else arg for arg in cmd_args]
-    
+
     result = runner.invoke(app, cmd_args)
     print(result.output)
     print(result.stderr)

--- a/tests/unit_tests/bin_quality_test.py
+++ b/tests/unit_tests/bin_quality_test.py
@@ -4,10 +4,7 @@ from pyroaring import BitMap
 
 from binette import bin_quality
 from binette.bin_manager import Bin
-from binette.bin_quality import (
-    balanced_chunks,
-    chunks,
-)
+from binette.bin_quality import balanced_chunks, chunks
 
 
 def test_compute_N50():


### PR DESCRIPTION
Before quiet mode was the default. but now logging info is the default. If needed the quiet flag can be used to comeback to no info and debug log at all. 